### PR TITLE
Remplacement de la référence vers spatialreference.org par epsg.io

### DIFF
--- a/README-leaflet.md
+++ b/README-leaflet.md
@@ -161,7 +161,7 @@ var utm20 = new L.Proj.CRS('EPSG:4559',
 
 ```
 
-NB : Le site [spatialreference.org](http://spatialreference.org/) recense un grand nombre de registres de systèmes de coordonnées avec leurs définitions.
+NB : Le site [epsg.io](http://epsg.io/) recense un grand nombre de registres de systèmes de coordonnées avec leurs définitions.
 
 
 L'extension Géoportail pour Leaflet définit par défaut la projection légale Lambert 93 (EPSG:2154) qu'elle expose sous la variable globale suivante.

--- a/README-ol3.md
+++ b/README-ol3.md
@@ -179,7 +179,7 @@ L'extension Géoportail pour OpenLayers 3 définit par défaut la projection lé
 
 NB :
 
-* Le site [spatialreference.org](http://spatialreference.org/) recense un grand nombre de registres de systèmes de coordonnées avec leurs définitions.
+* Le site [epsg.io](http://epsg.io/) recense un grand nombre de registres de systèmes de coordonnées avec leurs définitions.
 
 * Les définitions des systèmes de coordonnées du registre IGNF peuvent être trouvées [ici](https://github.com/OSGeo/proj.4/blob/master/nad/IGNF).
 


### PR DESCRIPTION
Le premier site est dépassé et n'est plus maintenu. Il n'est plus recommandé ni même cité dans le workshop officiel OpenLayers http://openlayers.org/workshop/layers/cached.html ou les exemples.