### PR TITLE
Gestion des interactions entre extensions

### DIFF
--- a/samples/ol3/Drawing/index-amd.html
+++ b/samples/ol3/Drawing/index-amd.html
@@ -115,6 +115,12 @@
                     map.addControl(drawing);
                     map.addControl(mp);
 
+                    drawing.on(
+                        "change:collapsed",
+                        function (e) {
+                            console.log("change:collapsed : collapsed =", e.target.collapsed);
+                        }
+                    );
                   };
 
                   Gp.Services.getConfig({

--- a/src/Common/Controls/DrawingDOM.js
+++ b/src/Common/Controls/DrawingDOM.js
@@ -48,11 +48,27 @@ define([], function () {
         */
         _createShowDrawingPictoElement : function () {
 
+            var self = this;
+
             var label = document.createElement("label");
             label.id  = this._addUID("GPshowDrawingPicto") ;
             label.className = "GPshowAdvancedToolPicto";
             label.htmlFor = this._addUID("GPshowDrawing");
             label.title = this.options.labels.control ;
+
+            // gestionnaire d'evenement :
+            // on ouvre le menu de saisie de saisie
+            // L'ouverture/Fermeture permet de faire le menage
+            // (reinitialisation)
+            if (label.addEventListener) {
+                label.addEventListener("click", function (e) {
+                    self.onShowDrawingClick(e);
+                });
+            } else if (label.attachEvent) {
+                label.attachEvent("onclick", function (e) {
+                    self.onShowDrawingClick(e);
+                });
+            }
 
             var spanOpen = document.createElement("span");
             spanOpen.id  = this._addUID("GPshowDrawingOpen") ;

--- a/src/Ol3/Controls/Drawing.js
+++ b/src/Ol3/Controls/Drawing.js
@@ -3,6 +3,7 @@ define([
     "ol",
     "gp",
     "Common/Utils/SelectorID",
+    "Ol3/Controls/Utils/Interactions",
     "Common/Controls/DrawingDOM",
     "Ol3/Utils",
     "Ol3/Formats/KML"
@@ -11,6 +12,7 @@ define([
     ol,
     Gp,
     SelectorID,
+    Interactions,
     DrawingDOM,
     Utils,
     KMLExtended
@@ -1180,6 +1182,11 @@ define([
             logger.trace("Drawing control not attached to any map.") ;
             return ;
         }
+        // on supprime  les interactions des autres extensions
+        Interactions.unset(map, {
+            current : "Drawing"
+        });
+
         // on supprime  l'interaction courante s'il y en a une.
         if (context.interaction) {
             map.removeInteraction(context.interaction) ;
@@ -1388,6 +1395,10 @@ define([
                 logger.trace("unhandled tool type") ;
         }
         if (context.interaction) {
+            context.interaction.setProperties({
+                name : "Drawing",
+                source : this
+            });
             map.addInteraction(context.interaction) ;
         }
     } ;
@@ -1405,6 +1416,10 @@ define([
      * @private
      */
     Drawing.prototype.onShowDrawingClick = function () {
+
+        var map = this.getMap();
+        // on supprime toutes les interactions
+        Interactions.unset(map);
 
         // checked : true - panel close
         // checked : false - panel open

--- a/src/Ol3/Controls/Measures/MeasureAzimuth.js
+++ b/src/Ol3/Controls/Measures/MeasureAzimuth.js
@@ -113,7 +113,7 @@ define([
      */
     MeasureAzimuth.prototype.setMap = function (map) {
         logger.trace("setMap()");
-        
+
         var className = this.CLASSNAME;
 
         // on fait le choix de ne pas activer les events sur la map à l'init de l'outil,

--- a/src/Ol3/Controls/Measures/MeasureLength.js
+++ b/src/Ol3/Controls/Measures/MeasureLength.js
@@ -77,6 +77,7 @@ define([
                 render : options.render
             }
         );
+
     }
 
     // heritage avec ol.control.Control

--- a/src/Ol3/Controls/Measures/Measures.js
+++ b/src/Ol3/Controls/Measures/Measures.js
@@ -1,9 +1,11 @@
 define([
     "ol",
-    "woodman"
+    "woodman",
+    "Ol3/Controls/Utils/Interactions"
 ], function (
     ol,
-    woodman
+    woodman,
+    Interactions
 ) {
 
     "use strict";
@@ -214,14 +216,11 @@ define([
                 }
             }
 
-            // FIXME desactivation des autres interactions parasites
+            // desactivation des autres interactions parasites
             var map = this.getMap();
-            var interactions = map.getInteractions().getArray() ;
-            for (var i = 0 ; i < interactions.length ; i++ ) {
-                if (interactions[i].getActive() && interactions[i] instanceof ol.interaction.Draw) {
-                    interactions[i].setActive(false);
-                }
-            }
+            Interactions.unset(map, {
+                current : "Measures"
+            });
 
             if (!this._showContainer.checked) {
 
@@ -278,7 +277,6 @@ define([
         * Clear all length, area or azimut object.
         */
         clearMeasure : function () {
-            logger.trace("call Measures::clear()");
 
             var map = this.getMap();
 
@@ -417,7 +415,8 @@ define([
                 style : this.options.styles.start || Measures.DEFAULT_DRAW_START_STYLE
             });
             this.measureDraw.setProperties({
-                source : "Measure"
+                name : "Measures",
+                source : this
             });
             map.addInteraction(this.measureDraw);
 

--- a/src/Ol3/Controls/Utils/Interactions.js
+++ b/src/Ol3/Controls/Utils/Interactions.js
@@ -1,0 +1,117 @@
+define([
+    "ol",
+    "woodman",
+    "Ol3/Utils"
+], function (
+    ol,
+    woodman,
+    Utils
+) {
+
+    "use strict";
+
+    woodman.load("console");
+    var logger = woodman.getLogger("interactions");
+
+    /**
+    * HOWTO
+    * Pourquoi et comment l'utiliser ?
+    * Cette classe permet de gérer les interactions entre chaque extension.
+    * Une extension qui active une interaction avec la carte, doit desactiver
+    * les autres interactions issues d'autre extensions.
+    * La désactivation d'une interaction s'accompagne d'actions telles que
+    * le nettoyage des dessins, l'état du composant graphique, ...
+    *
+    * Ex
+    * // desactive toutes les interactions avec l'opération par defaut : clean
+    * Interactions.unset(map);
+    * // desactive les interactions sauf celles de Drawing. On execute des
+    * // operations particulieres : status, collapse et message
+    * Interactions.unset(map, {
+    *    current : "Drawing",
+    *    status : false,
+    *    collapse : true,
+    *    messsage : ["WARNING", "Ceci est un avertissement !"]
+    * });
+    *
+    * Dans le code de l'extension, il faut placer des informations dans l'interaction :
+    * interaction.setProperties({
+    *     name : "Drawing",
+    *     source : this
+    * });
+    */
+    var Interactions = {
+
+        /**
+         * Liste des extensions qui utilisent le mécanisme des interactions
+         */
+        _extensions : [
+            "Measures",
+            "ElevationPath",
+            "Drawing"
+        ],
+
+        /**
+         * Options par defaut
+         * - current : ex. "Drawing"
+         *       c'est l'extension qui demande la desactivation des autres interactions.
+         *       Par defaut, toutes les interactions sont desactivées.
+         * - clean :
+         *       c'est la suppression des interactions, des dessins de la carte,
+         *       ainsi que la reinitialisation de l'état graphique.
+         *       Les extensions doivent implementer la méthode 'clean()'.
+         *       Par defaut, tous les dessins sont supprimés
+         */
+        _options : {
+            current : null,
+            clean : null
+        },
+
+        /**
+         * Permet de desactive les interactions (Draw) de la carte pour les extensions,
+         * sauf l'interaction courrante (si elle est renseignée avec l'option 'current').
+         * Il est possible d'ajouter des fonctionnalités via les options.
+         * Par defaut, l'option 'clean' est renseignée...
+         */
+        unset : function (map, options) {
+            logger.trace("unset()");
+
+            var opts = {};
+            Utils.mergeParams(opts, this._options);
+            Utils.mergeParams(opts, options);
+
+            var interactions = map.getInteractions().getArray() ;
+            for (var i = 0 ; i < interactions.length ; i++ ) {
+                if (interactions[i].getActive() && interactions[i] instanceof ol.interaction.Draw) {
+                    var prop = interactions[i].getProperties();
+                    var name =  prop.name;
+                    if ( typeof name !== "undefined" && this._extensions.indexOf(name) > -1) {
+                        // doit on desactiver l'interaction courrante ?
+                        if (opts.current && opts.current === name) {
+                            continue;
+                        }
+                        interactions[i].setActive(false);
+                        // instance de l'extension
+                        var source = prop.source;
+                        if ( typeof source !== "undefined" && source instanceof ol.control.Control ) {
+                            // opérations sur le composant graphique
+                            for (var action in opts) {
+                                if (opts.hasOwnProperty(action)) {
+                                    if (action === "current") {
+                                        continue;
+                                    }
+                                    if ( typeof source[action] === "function") {
+                                        var args = Array.isArray(opts[action]) ? opts[action] : [opts[action]];
+                                        source[action].apply(source, args);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    return Interactions;
+});


### PR DESCRIPTION
Mise en place d'un mécanisme (simple) pour gérer les interactions entre extensions.

_Pourquoi et comment l'utiliser ?_

Cette classe permet de gérer les interactions entre chaque extension.
Une extension qui met en place une interaction avec la carte, doit désactiver
les autres interactions en cours sur les autres extensions.
La désactivation d'une interaction s'accompagne d'actions telles que
le nettoyage des dessins, la réinitialisation de l'état graphique, ...

_Exemples :_
Pour désactiver toutes les interactions, et exécuter l'opération par défaut : clean
`Interactions.unset(map);`

Pour désactiver les interactions sauf celles de **Drawing**. 
Et on souhaite exécuter des opérations particulières : status, collapse et message
 ```
 Interactions.unset(map, {
        current : "Drawing",
        status : false,
        collapse : true,
        messsage : ["WARNING", "Ceci est un avertissement !"]
 });
```
Les extensions doivent implémenter les méthodes d'opération.
A minima, la méthode 'clean()' devrait être présente dans chaque extension...
