### PR TITLE
Reintroduce filtering of unwanted properties in popups

### DIFF
--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -189,7 +189,11 @@ define([
                 var ul = null ;
                 var li = null ;
                 for (p in props) {
-                    if (p == "geometry" || p == "name" || p == "description") {
+                    if (p == "geometry" || p == "value" || p == "name" || p == "description" || p == "styleUrl") {
+                        continue ;
+                    }
+                    // FIXME La lecture des extensions GPX n'est pas gérée !
+                    if (p == "extensionsNode_" && props[p] === undefined) {
                         continue ;
                     }
                     if (!others) {


### PR DESCRIPTION
Au clic sur les features KML ou GPX, certains attributs non pertinents sont présentés : 

* styleUrl : instructions de style des KML
* extensionsNode_ : dans le GPX

Ces attributs étaient filtrés lorsque le getfeatureInfo était géré au niveau du SDK, mais cela a du se perdre dans le rajout du controle GetFeatureInfo.