### PR TITLE
fix #135 : display mouseposition coordinates units

### DIFF
--- a/src/Leaflet/Controls/MousePosition.js
+++ b/src/Leaflet/Controls/MousePosition.js
@@ -653,7 +653,7 @@ define([
             var coordinate = {};
             coordinate.lat = PositionFormater.roundToDecimal(oLatLng.lat, 6);
             coordinate.lng = PositionFormater.roundToDecimal(oLatLng.lng, 6);
-            // Sans unité... coordinate.unit = "deg";
+            coordinate.unit = "°";
             return coordinate;
         },
 
@@ -679,7 +679,7 @@ define([
             var coordinate = {};
             coordinate.lat = PositionFormater.decimalToRadian(oLatLng.lat);
             coordinate.lng = PositionFormater.decimalToRadian(oLatLng.lng);
-            // Sans unité... coordinate.unit = "rad";
+            coordinate.unit = "rad";
             return coordinate;
 
         },
@@ -693,7 +693,7 @@ define([
             var coordinate = {};
             coordinate.lat = PositionFormater.decimalToGrade(oLatLng.lat);
             coordinate.lng = PositionFormater.decimalToGrade(oLatLng.lng);
-            // Sans unité... coordinate.unit = "gon";
+            coordinate.unit = "gon";
             return coordinate;
 
         },

--- a/src/Ol3/Controls/MousePosition.js
+++ b/src/Ol3/Controls/MousePosition.js
@@ -937,6 +937,7 @@ define([
         var coordinate = {};
         coordinate.lat = olCoordinate[1].toFixed(6);
         coordinate.lng = olCoordinate[0].toFixed(6);
+        coordinate.unit = "°";
         return coordinate;
     };
 
@@ -971,6 +972,7 @@ define([
         coordinate.lng = coordinate.lng.toFixed(8);
         coordinate.lat = olCoordinate[1] * d;
         coordinate.lat = coordinate.lat.toFixed(8);
+        coordinate.unit = "rad";
         return coordinate;
     };
 
@@ -989,6 +991,7 @@ define([
         coordinate.lng = coordinate.lng.toFixed(8);
         coordinate.lat = olCoordinate[1] * d;
         coordinate.lat = coordinate.lat.toFixed(8);
+        coordinate.unit = "gon";
         return coordinate;
     };
 
@@ -1448,7 +1451,7 @@ define([
 
         var coordinate = ol.proj.transform(lonlat, oSrs, view.getProjection());
         view.setCenter(coordinate);
-        
+
         if (this._markerOverlay && ! this._hideMarker) {
             this._markerOverlay.setPosition(coordinate);
         }

--- a/src/Vg/Controls/MousePosition.js
+++ b/src/Vg/Controls/MousePosition.js
@@ -547,11 +547,11 @@ define([
                 label : "Lambert 93",
                 crs : "EPSG:2154",
                 type : "Metric",
-                geoBBox : { 
-                    left : -9.86, 
-                    bottom : 41.15, 
-                    right : 10.38, 
-                    top : 51.56 
+                geoBBox : {
+                    left : -9.86,
+                    bottom : 41.15,
+                    right : 10.38,
+                    top : 51.56
                 }
             },
             {
@@ -559,10 +559,10 @@ define([
                 crs : "EPSG:27572",
                 type : "Metric",
                 geoBBox : {
-                    left : -4.87, 
-                    bottom : 42.33, 
-                    right : 8.23, 
-                    top : 51.14 
+                    left : -4.87,
+                    bottom : 42.33,
+                    right : 8.23,
+                    top : 51.14
                 }
             }
         ];
@@ -877,6 +877,7 @@ define([
         var coordinate = {};
         coordinate.lat = PositionFormater.roundToDecimal(coords.lat, 6);
         coordinate.lng = PositionFormater.roundToDecimal(coords.lon, 6);
+        coordinate.unit = "°";
         return coordinate;
     };
 
@@ -907,6 +908,7 @@ define([
         var coordinate = {};
         coordinate.lat = PositionFormater.decimalToRadian(coords.lat);
         coordinate.lng = PositionFormater.decimalToRadian(coords.lon);
+        coordinate.unit = "rad";
         return coordinate;
     };
 
@@ -922,6 +924,7 @@ define([
         var coordinate = {};
         coordinate.lat = PositionFormater.decimalToGrade(coords.lat);
         coordinate.lng = PositionFormater.decimalToGrade(coords.lon);
+        coordinate.unit = "gon";
         return coordinate;
     };
 


### PR DESCRIPTION
L'affichage des unités des coordonnées dans l'outil d'affichage de la position de la souris (MousePosition) n'était effectif que pour les degrés sexagécimaux et pour les coordonnées métriques (m et km). (voir #135)

Cette PR permet de les afficher aussi dans le cas des degrés décimaux, des radians et des grades, pour les différentes librairies sous-jacentes. 