### PR TITLE
fix #146 : clean previous attributions only for Geoportal Layers

### DIFF
--- a/samples/ol3/Originators/index-default-controls.html
+++ b/samples/ol3/Originators/index-default-controls.html
@@ -78,6 +78,11 @@
                             // className : "gp-attribution"
                         }
                     ));
+                    map.addControl(
+                        new ol.control.LayerSwitcher({
+                            collapsed : false
+                        })
+                    );
                 }
             </script>
 

--- a/src/Ol3/Controls/GeoportalAttribution.js
+++ b/src/Ol3/Controls/GeoportalAttribution.js
@@ -157,12 +157,16 @@ define(["ol", "Common/Utils/LayerUtils"], function (ol, LayerUtils) {
      */
     GeoportalAttribution.prototype._updateLayerAttributions = function (layer, mapAttributions, mapExtent, mapCrs, mapZoom) {
         var src = layer.getSource();
-        src.setAttributions(); // clean
 
         var attributions = [];
 
         var visibility = layer.getVisible();
         var originators = src._originators;
+
+        // info : clean previous attributions ONLY for Geoportal Layers (when src._originators is defined)
+        if ( typeof originators !== "undefined" ) {
+            src.setAttributions(); // clean
+        }
 
         if ( originators && visibility ) {
 


### PR DESCRIPTION
to preserve other attributions, OSM for instance