### PR TITLE
Debug CSS rules based on dje remarks

### DIFF
--- a/res/Common/GPdrawing.css
+++ b/res/Common/GPdrawing.css
@@ -24,14 +24,14 @@ input[id^=GPshowDrawing-]:checked + label + div {
 
 /* General panels */
 
-div[^=GPdrawingPanel-] {
+div[id^=GPdrawingPanel-] {
   width: 240px;
   overflow: hidden;
 }
 
 /* Basic infos */
 
-div[^=GPdrawingBasicPanel-] {
+div[id^=GPdrawingBasicPanel-] {
   padding: 10px 15px;
 }
 

--- a/res/Ol3/Controls/ToolBoxMeasure/GPtoolBoxMeasureOL3.css
+++ b/res/Ol3/Controls/ToolBoxMeasure/GPtoolBoxMeasureOL3.css
@@ -8,7 +8,7 @@ div[id^=GPtoolbox-measure-main] {
   left: 78px;
   top: 8px;
   position: absolute;
-  display: inline-block;￼
+  display: inline-block;
   z-index: 1;
 }
 


### PR DESCRIPTION

> En installant le SDK, je me suis aperçu de plusieurs coquilles dans les fichiers CSS. Par deux fois on peut lire le sélecteur suivant :
> div[^=GPdrawingPanel-]
> div[^=GPdrawingBasicPanel-]
>  
> Le souci est que rien n’est défini comme attribut matchant la chaîne de caractères. Je pense qu’il manque un id :
> div[id^=GPdrawingPanel-]
> div[id^=GPdrawingBasicPanel-]
>  
> Autre coquille relevée : il y a des caractères bizarres avant et après la propriété margin-top:auto du sélecteur ul#data-default
> On trouve le même caractère bizarre après la propriété display:inline-block du sélecteur #GPtoolbox-measure-main
>  
> Dans le meilleur des cas, les règles CSS ne seront pas appliquées. Dans le pire (c’est ce qui m’est arrivé), si le déploiement Web passe par une étape de précompilation des sources alors ça plante carrément le déploiement.
> Je ne suis pas allé verifier que ces coquilles existent aussi dans les fichiers des extensions OpenLayers et Leaflet, mais c’est pas impossible.

Effectivement, le problème réside au niveau des CSS des extensions. Cette PR a pour but de corriger cela.

NB : je n'ai pas trouvé la ligne correspondant à : 

> Autre coquille relevée : il y a des caractères bizarres avant et après la propriété margin-top:auto du sélecteur ul#data-default

Ni dans le SDK, ni dans les extensions. Elle a peut-être disparue depuis la dernière version du SDK (qui commence à dater)