### PR TITLE
Recentrage de la pop-up lorsqu'elle apparaît en dehors du canvas

### DIFF
--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -147,6 +147,10 @@ define([
             map.featuresOverlay = new ol.Overlay({
                 // id : id,
                 element : element,
+                autoPan : true,
+                autoPanAnimation : {
+                    duration : 250
+                },
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -46,9 +46,12 @@ define([
          * @param {ol.Coordinate} coords - coordinates where to anchor popup.
          * @param {String} content - content to display
          * @param {String} [contentType='text/html'] - content mime-type
+         * @param {Object} autoPanOptions - Auto-pan pop-up options
+         * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
+         * @param {Object} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
-        displayInfo : function (map, coords, content, contentType) {
+        displayInfo : function (map, coords, content, contentType, autoPanOptions) {
             logger.trace("[GfiUtils] : displayInfo...") ;
 
             if ( !contentType ) {
@@ -65,6 +68,12 @@ define([
             var _content = content;
             _content = _content.replace(/\n/g, "");
             _content = _content.replace(/(>)\s*(<)/g, "$1$2");
+
+            if ( autoPanOptions === undefined ) {
+                autoPanOptions = {
+                    autoPan : true
+                };
+            }
 
             var scope  = typeof window !== "undefined" ? window : null;
 
@@ -147,10 +156,8 @@ define([
             map.featuresOverlay = new ol.Overlay({
                 // id : id,
                 element : element,
-                autoPan : true,
-                autoPanAnimation : {
-                    duration : 250
-                },
+                autoPan : autoPanOptions.autoPan,
+                autoPanAnimation : autoPanOptions.autoPanAnimation,
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -48,7 +48,8 @@ define([
          * @param {String} [contentType='text/html'] - content mime-type
          * @param {Object} autoPanOptions - Auto-pan pop-up options
          * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
-         * @param {Object} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+         * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+         * @param {Number} [autoPanOptions.autoPanMargin] -Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
         displayInfo : function (map, coords, content, contentType, autoPanOptions) {
@@ -158,6 +159,7 @@ define([
                 element : element,
                 autoPan : autoPanOptions.autoPan,
                 autoPanAnimation : autoPanOptions.autoPanAnimation,
+                autoPanMargin : autoPanOptions.autoPanMargin,
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -49,7 +49,7 @@ define([
          * @param {Object} autoPanOptions - Auto-pan pop-up options
          * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
          * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
-         * @param {Number} [autoPanOptions.autoPanMargin] -Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
+         * @param {Number} [autoPanOptions.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
         displayInfo : function (map, coords, content, contentType, autoPanOptions) {


### PR DESCRIPTION
Voir issue #170 

Recentrer la pop-up lorsqu'elle apparait en dehors du canvas est un comportement classique !