### PR TITLE
Ajout du paramètre autoPanOptions pour permettre le recentrage automatique des pop-up

### DIFF
--- a/src/Ol3/Controls/GetFeatureInfo.js
+++ b/src/Ol3/Controls/GetFeatureInfo.js
@@ -179,7 +179,7 @@ define([
                 console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a boolean");
                 return;
             }
-            this._autoPan = options.autoPan;
+            this._autoPan = typeof options.autoPan === "undefined" ? true : options.autoPan;
         }
 
         if ( options.autoPanAnimation ) {

--- a/src/Ol3/Controls/GetFeatureInfo.js
+++ b/src/Ol3/Controls/GetFeatureInfo.js
@@ -174,13 +174,11 @@ define([
             this._noProxyDomains = options.noProxyDomains;
         }
 
-        if ( options.autoPan ) {
-            if ( typeof options.autoPan !== "undefined" &&  typeof options.autoPan !== "boolean" ) {
-                console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a boolean");
-                return;
-            }
-            this._autoPan = typeof options.autoPan === "undefined" ? true : options.autoPan;
+        if ( typeof options.autoPan !== "undefined" &&  typeof options.autoPan !== "boolean" ) {
+            console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a boolean");
+            return;
         }
+        this._autoPan = ( typeof options.autoPan === "undefined" ) ? true : options.autoPan;
 
         if ( options.autoPanAnimation ) {
             if (options.autoPanAnimation.duration) {

--- a/src/Ol3/Controls/GetFeatureInfo.js
+++ b/src/Ol3/Controls/GetFeatureInfo.js
@@ -175,8 +175,8 @@ define([
         }
 
         if ( options.autoPan ) {
-            if ( typeof options.boolean !== "undefined" &&  typeof options.autoPan !== "boolean" ) {
-                console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a string");
+            if ( typeof options.autoPan !== "undefined" &&  typeof options.autoPan !== "boolean" ) {
+                console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a boolean");
                 return;
             }
             this._autoPan = options.autoPan;

--- a/src/Ol3/Controls/GetFeatureInfo.js
+++ b/src/Ol3/Controls/GetFeatureInfo.js
@@ -41,6 +41,9 @@ define([
      * @param {String} [gfiOptions.options.cursorStyle='pointer'] - specifies the type of cursor to be displayed when pointing on vector feature of a layer previously added to the control. The value must be choosen in the possible values of the css cursor property.
      * @param {String} [gfiOptions.options.proxyUrl] - Proxy URL to avoid cross-domain problems.
      * @param {Array.<String>} [gfiOptions.options.noProxyDomains] - Proxy will not be used for this list of domain names. Only use if you know what you're doing.
+     * @param {Boolean} [gfiOptions.options.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
+     * @param {olx.OverlayPanOptions} [gfiOptions.options.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+     * @param {Number} [gfiOptions.options.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
      */
     function GetFeatureInfo (gfiOptions) {
 
@@ -169,6 +172,39 @@ define([
                 return;
             }
             this._noProxyDomains = options.noProxyDomains;
+        }
+
+        if ( options.autoPan ) {
+            if ( typeof options.boolean !== "undefined" &&  typeof options.autoPan !== "boolean" ) {
+                console.log("[ERROR] GetFeatureInfo:_initialize - autoPan parameter should be a string");
+                return;
+            }
+            this._autoPan = options.autoPan;
+        }
+
+        if ( options.autoPanAnimation ) {
+            if (options.autoPanAnimation.duration) {
+                if ( typeof options.autoPanAnimation.duration !== "number" ) {
+                    console.log("[ERROR] GetFeatureInfo:_initialize - autoPanAnimation parameter is invalid : duration should be a number.");
+                    return;
+                }
+            }
+
+            if ( options.autoPanAnimation.easing) {
+                if ( typeof options.autoPanAnimation.easing !== "function" ) {
+                    console.log("[ERROR] GetFeatureInfo:_initialize - autoPanAnimation parameter is invalid : easing should be a ol.easing function or a custom function.");
+                    return;
+                }
+            }
+            this._autoPanAnimation = options.autoPanAnimation;
+        }
+
+        if ( options.autoPanMargin ) {
+            if ( typeof options.autoPanMargin !== "number" ) {
+                console.log("[ERROR] GetFeatureInfo:_initialize - autoPanMargin parameter should be a number");
+                return;
+            }
+            this._autoPanMargin = options.autoPanMargin;
         }
 
         // {Object} control layers list.

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -147,6 +147,10 @@ define([
             map.featuresOverlay = new ol.Overlay({
                 // id : id,
                 element : element,
+                autoPan : true,
+                autoPanAnimation : {
+                    duration : 250
+                },
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -47,7 +47,7 @@ define([
          * @param {String} content - content to display
          * @param {String} [contentType='text/html'] - content mime-type
          * @param {Object} autoPanOptions - Auto-pan pop-up options
-         * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
+         * @param {Boolean} [autoPanOptions.autoPan] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas
          * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
          * @param {Number} [autoPanOptions.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          * @return {Boolean} displayed - indicates if something has been displayed
@@ -69,12 +69,6 @@ define([
             var _content = content;
             _content = _content.replace(/\n/g, "");
             _content = _content.replace(/(>)\s*(<)/g, "$1$2");
-
-            if ( autoPanOptions === undefined ) {
-                autoPanOptions = {
-                    autoPan : true
-                };
-            }
 
             var scope  = typeof window !== "undefined" ? window : null;
 

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -46,9 +46,12 @@ define([
          * @param {ol.Coordinate} coords - coordinates where to anchor popup.
          * @param {String} content - content to display
          * @param {String} [contentType='text/html'] - content mime-type
+         * @param {Object} autoPanOptions - Auto-pan pop-up options
+         * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
+         * @param {Object} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
-        displayInfo : function (map, coords, content, contentType) {
+        displayInfo : function (map, coords, content, contentType, autoPanOptions) {
             logger.trace("[GfiUtils] : displayInfo...") ;
 
             if ( !contentType ) {
@@ -65,6 +68,12 @@ define([
             var _content = content;
             _content = _content.replace(/\n/g, "");
             _content = _content.replace(/(>)\s*(<)/g, "$1$2");
+
+            if ( autoPanOptions === undefined ) {
+                autoPanOptions = {
+                    autoPan : true
+                };
+            }
 
             var scope  = typeof window !== "undefined" ? window : null;
 
@@ -147,10 +156,8 @@ define([
             map.featuresOverlay = new ol.Overlay({
                 // id : id,
                 element : element,
-                autoPan : true,
-                autoPanAnimation : {
-                    duration : 250
-                },
+                autoPan : autoPanOptions.autoPan,
+                autoPanAnimation : autoPanOptions.autoPanAnimation,
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -266,7 +266,7 @@ define([
          * @param {Array.<ol.layer.Layer>} olLayers - layers requested
          *
          */
-        displayVectorFeatureInfo : function (map, olCoordinate, olLayers) {
+        displayVectorFeatureInfo : function (map, olCoordinate, olLayers, autoPanOptions) {
             var pixel = map.getPixelFromCoordinate(olCoordinate);
 
             // couches vecteur : on remplit un tableau avec les features à proximité.
@@ -286,7 +286,7 @@ define([
                 return false;
             }
             // Affichage des features.
-            this.displayInfo(map, olCoordinate, content.innerHTML) ;
+            this.displayInfo(map, olCoordinate, content.innerHTML, "text/html", autoPanOptions) ;
             // this._displayInfo(evt.coordinate,content,"text/html") ;
             return true;
         },
@@ -308,9 +308,13 @@ define([
          * @param {Object} [proxyOptions] - options for poxy configuration :
          * @param {String} [proxyOptions.proxyUrl] - Proxy URL to avoid cross-domain problems, if not already set in mapOptions. Mandatory to import WMS and WMTS layer.
          * @param {Array.<String>} [proxyOptions.noProxyDomains] - Proxy will not be used for this list of domain names. Only use if you know what you're doing (if not already set in mapOptions).
+         * @param {Object} [autoPanOptions] - Auto-pan pop-up options
+         * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
+         * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+         * @param {Number} [autoPanOptions.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          *
          */
-        displayFeatureInfo : function (map, olCoordinate, gfiLayers, proxyOptions) {
+        displayFeatureInfo : function (map, olCoordinate, gfiLayers, proxyOptions, autoPanOptions) {
             // Layers orders
             var layersOrdered = {};
             for ( var j = 0; j < gfiLayers.length; j++ ) {
@@ -436,7 +440,7 @@ define([
                                 }
                             }
                         }
-                        report( data.scope.displayVectorFeatureInfo(map, data.coordinate, vectorLayersOrdered) );
+                        report( data.scope.displayVectorFeatureInfo(map, data.coordinate, vectorLayersOrdered, autoPanOptions) );
                     } else {
                         // var self = data.scope;
                         Gp.Protocols.XHR.call({
@@ -456,7 +460,7 @@ define([
                                 }
 
                                 // on affiche la popup GFI !
-                                var displayed = !exception && context.displayInfo(map, data.coordinate, resp);
+                                var displayed = !exception && context.displayInfo(map, data.coordinate, resp, "text/html", autoPanOptions);
                                 // on reporte sur la prochaine requête...
                                 report(displayed);
                             },
@@ -538,6 +542,17 @@ define([
                 proxyOptions.noProxyDomains = gfiObj._noProxyDomains;
             }
 
+            var autoPanOptions = {};
+            if ( gfiObj._autoPan ) {
+                autoPanOptions.autoPan = gfiObj._autoPan;
+            }
+            if ( gfiObj._autoPanAnimation ) {
+                autoPanOptions.autoPanAnimation = gfiObj._autoPanAnimation;
+            }
+            if ( gfiObj._autoPanMargin ) {
+                autoPanOptions.autoPanMargin = gfiObj._autoPanMargin;
+            }
+
             var eventLayers = [];
             for ( var j = 0 ; j < gfiObj._layers.length ; ++j ) {
                 var event = (gfiObj._layers[j].event) ? gfiObj._layers[j].event : gfiObj._defaultEvent;
@@ -551,7 +566,7 @@ define([
 
             var coords = this.getPosition(e,map);
 
-            this.displayFeatureInfo(map, coords, eventLayers, proxyOptions);
+            this.displayFeatureInfo(map, coords, eventLayers, proxyOptions, autoPanOptions);
         }
     };
     return GfiUtils;

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -48,7 +48,8 @@ define([
          * @param {String} [contentType='text/html'] - content mime-type
          * @param {Object} autoPanOptions - Auto-pan pop-up options
          * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
-         * @param {Object} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+         * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
+         * @param {Number} [autoPanOptions.autoPanMargin] -Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
         displayInfo : function (map, coords, content, contentType, autoPanOptions) {
@@ -158,6 +159,7 @@ define([
                 element : element,
                 autoPan : autoPanOptions.autoPan,
                 autoPanAnimation : autoPanOptions.autoPanAnimation,
+                autoPanMargin : autoPanOptions.autoPanMargin,
                 positioning : "bottom-center",
                 insertFirst : false, // popup appears on top of other overlays if any
                 stopEvent : true

--- a/src/Ol3/GfiUtils.js
+++ b/src/Ol3/GfiUtils.js
@@ -49,7 +49,7 @@ define([
          * @param {Object} autoPanOptions - Auto-pan pop-up options
          * @param {Boolean} [autoPanOptions.autoPan = true] - Specifies whether the map should auto-pan if the pop-up is rendered outside of the canvas. Defaults to true.
          * @param {olx.OverlayPanOptions} [autoPanOptions.autoPanAnimation] - Used to customize the auto-pan animation. See {@link https://openlayers.org/en/latest/apidoc/olx.html#.OverlayPanOptions olx.OverlayPanOptions}.
-         * @param {Number} [autoPanOptions.autoPanMargin] -Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
+         * @param {Number} [autoPanOptions.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
          * @return {Boolean} displayed - indicates if something has been displayed
          */
         displayInfo : function (map, coords, content, contentType, autoPanOptions) {


### PR DESCRIPTION
Voir issue #170 

Cet ajout permet à l'utilisateur de renseigner les options autoPan, autoPanAnimation et autoPanMargin dans l'objet GetFeatureInfo, afin de personnaliser l'affichage de la pop-up lorsqu'elle apparaît en dehors du canvas.