### PR TITLE
Extension SearchEngine : navigation avec les touches du clavier sur les résultats de l'autocompletion

### DIFF
--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-services.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-services.html
@@ -1,0 +1,77 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet SearchEngine</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+          div#map {
+            width: 100%;
+            height: 500px;
+          }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout du Widget du moteur de recherche</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+          requirejs([
+            'gp',
+            'Leaflet/Layers/Layers',
+            'Leaflet/Controls/SearchEngine'
+          ], function (
+            Gp,
+            Layers,
+            SearchEngine
+          ) {
+
+            Gp.Services.getConfig({
+              serverUrl : "{{ config.resources }}/AutoConf.js",
+              callbackSuffix : "",
+              // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+              timeOut : 20000,
+              onSuccess : function () {
+
+                var wms = Layers.WMS({
+                  layer : "ORTHOIMAGERY.ORTHOPHOTOS",
+                });
+
+                var map  = L.map('map', {
+                  zoom : 2,
+                  center : L.latLng(48, 2)
+                });
+
+                wms.addTo(map);
+
+                var search = new SearchEngine({
+                  collapsed : false,
+                  geocodeOptions : {           
+                    returnFreeForm : false,
+                    filterOptions : {
+                      type : ["PositionOfInterest"],
+                      department : "77",
+                      nature : "Commune"
+                    }
+                  },
+                  autocompleteOptions : {
+                    serverUrl : "http://wxs.ign.fr/jhyvi0fgmnuxvfv0zjzorvdn/ols/apis/completion",
+                    filterOptions : {
+                      territory : ["DOMTOM"],
+                      type : ["PositionOfInterest"]
+                    }
+                  }
+                });
+
+                map.addControl(search);
+              }
+            })
+          });
+        </script>
+{{/content}}
+{{/extend}}

--- a/src/Common/Controls/SearchEngineDOM.js
+++ b/src/Common/Controls/SearchEngineDOM.js
@@ -112,6 +112,7 @@ define(["Common/Utils/SelectorID"], function (ID) {
             input.autocomplete = "off";
             // Manage autocomplete list appearance when filling the address input
             input.addEventListener("keyup", function (e) {
+
                 var charCode = e.which || e.keyCode;
                 if (charCode === 13 || charCode === 10 || charCode === 38 || charCode === 40) {
                     return;
@@ -135,15 +136,10 @@ define(["Common/Utils/SelectorID"], function (ID) {
 
             input.addEventListener("keydown" , function (e) {
                 // FIXME
-                // je desactive cet evenement car l'action clavier 'enter (13)'
-                // lance le submit de la form ! Ce comportement n'est pas souhaité car le
-                // submit execute un geocodage !
+                // l'action clavier 'enter (13)' lance le submit de la form ! 
+                // Ce comportement n'est pas souhaité car le submit execute un geocodage !
                 // Il faut donc trouver le moyen d'eviter le submit sur un return venant
                 // seulement d'une selection de suggestion...
-
-                if (true) {
-                    return;
-                }
 
                 var charCode = e.which || e.keyCode;
 
@@ -201,6 +197,8 @@ define(["Common/Utils/SelectorID"], function (ID) {
                         next.style["background-color"] = "#CEDBEF";
                         break;
                     case 13 : // enter
+                        // cf. FIXME 
+                        e.preventDefault();
                         current.click(e);
                         break;
                 }

--- a/src/Leaflet/Controls/SearchEngine.js
+++ b/src/Leaflet/Controls/SearchEngine.js
@@ -897,7 +897,7 @@ define([
             // on y force le param suivant, s'il n'a pas été surchargé :
             if (!options.hasOwnProperty("returnFreeForm")) {
                 L.Util.extend(options, {
-                    returnFreeForm : false
+                    returnFreeForm : true
                 });
             }
 


### PR DESCRIPTION
Mise en place de la navigation avec les touches du clavier sur les résultats de l'autocompletion...
+ bug sur la recherche par geocodage de l'extension Leaflet en passant le bon paramètre `returnFreeform=true` à la requête...

Cette PR fait suite à l'issue #164 ...