### PR TITLE
Embarquer les mesures dans l'outil de dessin...

### DIFF
--- a/res/Ol3/Controls/Drawing/GPdrawing.css
+++ b/res/Ol3/Controls/Drawing/GPdrawing.css
@@ -163,7 +163,7 @@ button[id^=drawing-export-] {
 .tool-form-submit {
     border: medium none;
     border-radius: 20px;
-    font-family: "Helvetica Neue",Arial,Helvetica,sans-serif; 
+    font-family: "Helvetica Neue",Arial,Helvetica,sans-serif;
     font-size: 0.9em;
     text-align: center;
     text-transform: uppercase;
@@ -172,8 +172,8 @@ button[id^=drawing-export-] {
     color: #fff;
 }
 
-/* 
- * popups 
+/*
+ * popups
  */
 .gp-label-div,
 .gp-styling-div {
@@ -207,6 +207,14 @@ button[id^=drawing-export-] {
   width: 240px;
   height: 80px;
   resize: none;
+}
+
+.gp-input-measure-style {
+  width: 240px;
+  font-size: 0.75em;
+  background-color: #FFF;
+  text-align: center;
+  border-radius: 10px;
 }
 
 .gp-textarea-att-label-style {

--- a/samples-src/pages/ol3/Drawing/pages-ol-drawing-amd-display-measure.html
+++ b/samples-src/pages/ol3/Drawing/pages-ol-drawing-amd-display-measure.html
@@ -1,0 +1,85 @@
+{{#extend "ol-sample-amd-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3 Drawing</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                max-width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout des outils de dessin en mode AMD</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script>
+                var map;
+                requirejs([
+                  "ol",
+                  "gp",
+                  "Ol3/Layers/LayerWMTS",
+                  "Ol3/Controls/MousePosition",
+                  "Ol3/Controls/Drawing"
+                ],
+                function (
+                  ol,
+                  Gp,
+                  LayerWMTS,
+                  MousePosition,
+                  Drawing
+                ) {
+
+                  var createMap = function () {
+
+                    // Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        layers : [new LayerWMTS({
+                            layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
+                        })],
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 8
+                        })
+                    });
+
+                    var mp = new MousePosition({});
+
+                    // creation du controle
+                    var drawing = new Drawing({
+                        collapsed : false,
+                        tools : {
+                            measure : true
+                        }
+                    });
+                    map.addControl(drawing);
+                    map.addControl(mp);
+
+                    drawing.on(
+                        "change:collapsed",
+                        function (e) {
+                            console.log("change:collapsed : collapsed =", e.target.collapsed);
+                        }
+                    );
+                  };
+
+                  Gp.Services.getConfig({
+                      serverUrl : "{{ config.resources }}/AutoConf.js",
+                      callbackSuffix : "",
+                      // apiKey: "jhyvi0fgmnuxvfv0zjzorvdn",
+                      timeOut : 20000,
+                      onSuccess : createMap
+                  });
+                });
+            </script>
+{{/content}}
+{{/extend}}

--- a/src/Common/Controls/DrawingDOM.js
+++ b/src/Common/Controls/DrawingDOM.js
@@ -598,6 +598,7 @@ define([], function () {
          * @param {Object} options - options for popup
          * @param {String} options.geomType - gemeotryType selected ("Point", "Line" or "Polygon")
          * @param {String} options.text - text to fill input.
+         * @param {String} options.measure - measure to fill input.
          * @param {String} options.placeholder - placeholder for text input.
          * @param {String} options.inputId - text input id.
          * @param {Function} options.applyFunc - function called when text is to be saved.
@@ -617,6 +618,9 @@ define([], function () {
                 inputLabel.rows = 2 ;
                 inputLabel.cols = 40 ;
                 inputLabel.className = "gp-textarea-att-label-style" ;
+                if (options.measure) {
+                    inputLabel.value = options.measure;
+                }
             }
             if (options.text) {
                 inputLabel.value = options.text ;

--- a/src/Common/Controls/DrawingDOM.js
+++ b/src/Common/Controls/DrawingDOM.js
@@ -618,13 +618,12 @@ define([], function () {
                 inputLabel.rows = 2 ;
                 inputLabel.cols = 40 ;
                 inputLabel.className = "gp-textarea-att-label-style" ;
-                if (options.measure) {
-                    inputLabel.value = options.measure;
-                }
             }
+
             if (options.text) {
                 inputLabel.value = options.text ;
             }
+
             inputLabel.autocomplete = "off" ;
             inputLabel.placeholder = options.placeholder ;
             inputLabel.id = options.inputId ;
@@ -642,6 +641,16 @@ define([], function () {
                     options.applyFunc.call(this,inputLabel.value,false) ;
                 }
             } ;
+
+            if (options.measure && options.geomType != "Text") {
+                var inputMeasure = document.createElement("input");
+                inputMeasure.type = "text";
+                inputMeasure.readonly = true;
+                inputMeasure.className = "gp-input-measure-style" ;
+                inputMeasure.value = options.measure;
+                popup.appendChild(inputMeasure);
+            }
+
             if (options.geomType != "Text") {
                 // apply button
                 var applyButton = document.createElement("input") ;

--- a/src/Ol3/Controls/Utils/Interactions.js
+++ b/src/Ol3/Controls/Utils/Interactions.js
@@ -82,7 +82,11 @@ define([
 
             var interactions = map.getInteractions().getArray() ;
             for (var i = 0 ; i < interactions.length ; i++ ) {
-                if (interactions[i].getActive() && interactions[i] instanceof ol.interaction.Draw) {
+                if (interactions[i].getActive() &&
+                   (interactions[i] instanceof ol.interaction.Draw ||
+                    interactions[i] instanceof ol.interaction.Select ||
+                    interactions[i] instanceof ol.interaction.Modify)) {
+
                     var prop = interactions[i].getProperties();
                     var name =  prop.name;
                     if ( typeof name !== "undefined" && this._extensions.indexOf(name) > -1) {


### PR DESCRIPTION
PR fait suite à l'issue #103 : _Embarquer les mesures dans l'outil..._

Il est possible de connaitre les coordonnées, la distance ou la surface d'un objet saisie avec l'outil de dessin avec l'option suivante : 
```
var drawing = new ol.control.Drawing({
  tools : { 
    measure : true
  }
});
```
Cette information est affichée dans la fenêtre de **saisie de description**.
Ex. Surface
![selection_008](https://user-images.githubusercontent.com/10401006/34945489-dd49ae5c-fa03-11e7-8da5-d50c603eb0ea.png)
Ex. Distance
![selection_009](https://user-images.githubusercontent.com/10401006/34945510-ee8ef316-fa03-11e7-8374-a55c13469836.png)
Ex. Point
![selection_010](https://user-images.githubusercontent.com/10401006/34945542-05e1b760-fa04-11e7-94b6-b68290f77611.png)

Cette information peut à tout moment être effacer ou service dans une description de l'utilisateur.

**Attention, les mesures sont approximatives (Ce ne sont pas des calculs géodésiques !)**
