### PR TITLE
Gestion du protocole http|https sur les extensions ("Layers")

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -81,6 +81,22 @@ Puis, relancer l'installation...
 Pour installation manuelle, ne pas oublier de mettre l'executable _phantomjs.exe_
 dans l'environnement d'execution de windows (ex. https://www.java.com/fr/download/help/path.xml)
 
+### Installation d'une version spécifique d'une dépendance via NPM
+
+Orienté developpement
+
+**ouvrir une console :**
+
+    // branche master du depot "IGNF/geoportal-access-lib" (dev)
+    npm install https://github.com/IGNF/geoportal-access-lib/tarball/master --no-save
+
+Upgrade de version
+
+**ouvrir une console :**
+
+    // publication openlayers en version 4.4.4
+    npm install openlayers@4.4.4 --no-save
+
 ### Compilation via GULP
 
 **ouvrir une console :**

--- a/samples-src/pages/leaflet/Default/pages-leaflet-es6.html
+++ b/samples-src/pages/leaflet/Default/pages-leaflet-es6.html
@@ -1,0 +1,63 @@
+{{#extend "layout-leaflet-sample-es6"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet ES6 module</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+          div#map {
+            width: 100%;
+            height: 500px;
+          }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout de tous les widgets</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+    <script type=module>
+
+    import * as Gp from "{{ config.baseurl }}/dist/leaflet/GpPluginLeaflet{{ config.mode }}.js";
+
+    self.Gp.Services.getConfig({
+      serverUrl : "{{ config.resources }}/AutoConf.js",
+      callbackSuffix : "",
+      onSuccess : function () {
+          // on cache l'image de chargement du Géoportail.
+          document.getElementById("map").style.backgroundImage = "none";
+
+          // Création de la map
+          var layer = L.geoportalLayer.WMS({
+            layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+          });
+
+          var map  = L.map('map', {
+            zoom : 2,
+            center : L.latLng(48, 2)
+          });
+
+          layer.addTo(map);
+
+          var iso = L.geoportalControl.Isocurve();
+          map.addControl(iso);
+          var layerSwitcher = L.geoportalControl.LayerSwitcher();
+          map.addControl(layerSwitcher);
+          var mp = L.geoportalControl.MousePosition();
+          map.addControl(mp);
+          var route = L.geoportalControl.Route();
+          map.addControl(route);
+          var reverse = L.geoportalControl.ReverseGeocode();
+          map.addControl(reverse);
+          var search = L.geoportalControl.SearchEngine();
+          map.addControl(search);
+          var measureProfil = L.geoportalControl.ElevationPath();
+          map.addControl(measureProfil);
+    }});
+    </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-default.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-default.html
@@ -1,0 +1,59 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/Layers"
+            ],
+            function (
+                Gp,
+                Layers
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wms = Layers.WMS({
+                            layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2)
+                        });
+
+                        wms.addTo(map);
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-direct.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-direct.html
@@ -1,0 +1,74 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/WMS"
+            ],
+            function (
+                Gp,
+                WMS
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wms = new WMS("http://wxs.ign.fr/jhyvi0fgmnuxvfv0zjzorvdn/geoportail/r/wms", {
+                            paramsNative : {
+                                minZoom : 1,
+                                maxZoom : 21
+                            },
+                            paramsWms   : {
+                                layers  : "ORTHOIMAGERY.ORTHOPHOTOS",
+                                styles  : "normal",
+                                format  : "image/jpeg",
+                                version : "1.3.0"
+                            },
+                            originators  : [],
+                            legends      : [],
+                            metadata     : [],
+                            title        : "",
+                            description  : "",
+                            quicklookUrl : ""
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2)
+                        });
+
+                        wms.addTo(map);
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-map.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wms-amd-map.html
@@ -1,0 +1,58 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/Layers"
+            ],
+            function (
+                Gp,
+                Layers
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wms = Layers.WMS({
+                            layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2),
+                            layers : [wms]
+                        });
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wms-bundle-default.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wms-bundle-default.html
@@ -1,0 +1,40 @@
+{{#extend "layout-leaflet-sample-bundle"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+          div#map {
+            width: 100%;
+            height: 500px;
+          }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+          /** onload */
+          window.onload = function () {
+
+              var wms = L.geoportalLayer.WMS({
+                  layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+              });
+
+              var map  = L.map("map", {
+                  zoom : 2,
+                  center : L.latLng(48, 2)
+              });
+
+              wms.addTo(map);
+          };
+        </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-default.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-default.html
@@ -1,0 +1,59 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMTS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/Layers"
+            ],
+            function (
+                Gp,
+                Layers
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wmts = Layers.WMTS({
+                            layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2)
+                        });
+
+                        wmts.addTo(map);
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-direct.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-direct.html
@@ -1,0 +1,75 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMTS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/WMTS"
+            ],
+            function (
+                Gp,
+                WMTS
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wmts = new WMTS("http://wxs.ign.fr/jhyvi0fgmnuxvfv0zjzorvdn/geoportail/wmts", {
+                            paramsNative : {
+                                minZoom : 1,
+                                maxZoom : 21
+                            },
+                            paramsWmts   : {
+                                layer   : "ORTHOIMAGERY.ORTHOPHOTOS",
+                                style   : "normal",
+                                format  : "image/jpeg",
+                                version : "1.0.0",
+                                tilematrixset : "PM"
+                            },
+                            originators  : [],
+                            legends      : [],
+                            metadata     : [],
+                            title        : "",
+                            description  : "",
+                            quicklookUrl : ""
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2)
+                        });
+
+                        wmts.addTo(map);
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-map.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-amd-map.html
@@ -1,0 +1,59 @@
+{{#extend "layout-leaflet-sample-amd"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+        div#map {
+            width: 100%;
+            height: 500px;
+        }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMTS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+        var map;
+        requirejs(
+            [
+                "gp",
+                "Leaflet/Layers/Layers"
+            ],
+            function (
+                Gp,
+                Layers
+            ) {
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    /** onsuccess */
+                    onSuccess : function () {
+
+                        var wmts = Layers.WMTS({
+                            layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                        });
+
+                        var map  = L.map("map", {
+                            zoom : 2,
+                            center : L.latLng(48, 2),
+                            layers : [wmts]
+                        });
+
+
+                    }
+                });
+            });
+            </script>
+    {{/content}}
+    {{/extend}}

--- a/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-bundle-default.html
+++ b/samples-src/pages/leaflet/Layers/pages-leaflet-wmts-bundle-default.html
@@ -1,0 +1,40 @@
+{{#extend "layout-leaflet-sample-bundle"}}
+
+{{#content "head"}}
+        <title>Sample Leaflet</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+          div#map {
+            width: 100%;
+            height: 500px;
+          }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+        <h2>Ajout d'une couche WMTS</h2>
+        <!-- map -->
+        <div id="map"></div>
+{{/content}}
+
+{{#content "js"}}
+        <script type="text/javascript">
+          /** onload */
+          window.onload = function () {
+
+              var wmts = L.geoportalLayer.WMTS({
+                  layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+              });
+
+              var map  = L.map("map", {
+                  zoom : 2,
+                  center : L.latLng(48, 2)
+              });
+
+              wmts.addTo(map);
+          };
+        </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/ol3/Default/pages-ol-es6.html
+++ b/samples-src/pages/ol3/Default/pages-ol-es6.html
@@ -1,0 +1,82 @@
+{{#extend "ol-sample-es6-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout de tous les widgets</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="module">
+
+            import * as Gp from "{{ config.baseurl }}/dist/ol3/GpPluginOl3{{ config.mode }}.js";
+
+            self.Gp.Services.getConfig({
+              serverUrl : "{{ config.resources }}/AutoConf.js",
+              callbackSuffix : "",
+              timeOut : 20000,
+              onSuccess : function () {
+                  // on cache l'image de chargement du Géoportail.
+                  document.getElementById("map").style.backgroundImage = "none";
+
+                  // Création de la map
+                  var map = new ol.Map({
+                    target : "map",
+                    layers : [
+                      new ol.layer.GeoportalWMTS({
+                        layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                      })
+                    ],
+                    view : new ol.View({
+                      center : [288074.8449901076, 6247982.515792289],
+                      zoom : 8
+                    })
+                  });
+
+                  var drawing = new ol.control.Drawing();
+                  map.addControl(drawing);
+                  var iso = new ol.control.Isocurve();
+                  map.addControl(iso);
+                  var layerImport = new ol.control.LayerImport();
+                  map.addControl(layerImport);
+                  var layerSwitcher = new ol.control.LayerSwitcher();
+                  map.addControl(layerSwitcher);
+                  var mp = new ol.control.GeoportalMousePosition();
+                  map.addControl(mp);
+                  var route = new ol.control.Route();
+                  map.addControl(route);
+                  var reverse = new ol.control.ReverseGeocode({});
+                  map.addControl(reverse);
+                  var search = new ol.control.SearchEngine({});
+                  map.addControl(search);
+
+                  var measureLength = new ol.control.MeasureLength();
+                  map.addControl(measureLength);
+                  var measureArea = new ol.control.MeasureArea();
+                  map.addControl(measureArea);
+                  var measureAzimuth = new ol.control.MeasureAzimuth();
+                  map.addControl(measureAzimuth);
+                  var measureProfil = new ol.control.ElevationPath();
+                  map.addControl(measureProfil);
+
+                  var attributions = new ol.control.GeoportalAttribution();
+                  map.addControl(attributions);
+            }});
+
+            </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-layerwms-bundle-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-layerwms-bundle-default.html
@@ -1,0 +1,46 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.GeoportalWMS({
+                                layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                            })
+                        ]
+                    });
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-layerwmts-bundle-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-layerwmts-bundle-default.html
@@ -1,0 +1,46 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMTS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.GeoportalWMTS({
+                                layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                            })
+                        ]
+                    });
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-sourcewms-bundle-L93.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-sourcewms-bundle-L93.html
@@ -1,0 +1,55 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMS en lambert 93</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    var gpLayer = new ol.layer.Tile({
+                        source : new ol.source.GeoportalWMS({
+                            layer : "ORTHOIMAGERY.ORTHOPHOTOS",
+                            olParams : {
+                                params : {
+                                    CRS : "EPSG:2154"
+                                }
+                            }
+                        })
+                    });
+
+                    map = new ol.Map({
+                        layers : [gpLayer],
+                        target : 'map',
+                        view : new ol.View({
+                            projection : "EPSG:2154",
+                            center : [600000, 6750000],
+                            zoom : 7
+                        })
+                    });
+
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-sourcewms-bundle-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-sourcewms-bundle-default.html
@@ -1,0 +1,49 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.Tile({
+                                source : new ol.source.GeoportalWMS({
+                                    layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                                }),
+                                opacity : 1
+                            })
+                        ]
+                    });
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-sourcewmts-bundle-L93.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-sourcewmts-bundle-L93.html
@@ -1,0 +1,49 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMTS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    var gpLayer = new ol.layer.Tile({
+                        source : new ol.source.GeoportalWMTS({
+                            layer : "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO.L93"
+                        })
+                    });
+
+                    map = new ol.Map({
+                        layers : [gpLayer],
+                        target : 'map',
+                        view : new ol.View({
+                            projection : "EPSG:2154",
+                            center : [600000, 6750000],
+                            zoom : 6
+                        })
+                    });
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-sourcewmts-bundle-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-sourcewmts-bundle-default.html
@@ -1,0 +1,54 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMTS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.Tile({
+                                source : new ol.source.GeoportalWMTS({
+                                    layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                                }),
+                                opacity : 0.8
+                            }),
+                            new ol.layer.Tile({
+                                source : new ol.source.GeoportalWMTS({
+                                    layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                                })
+                            })
+                        ]
+                    });
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-wms-amd-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-wms-amd-default.html
@@ -1,0 +1,72 @@
+{{#extend "ol-sample-amd-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMS, en mode AMD</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+            requirejs(
+              [
+                "ol",
+                "gp",
+                "Ol3/Layers/LayerWMS"
+              ],
+              function (
+                ol,
+                Gp,
+                LayerWMS
+              ) {
+
+                var map;
+
+                /** createMap */
+                var createMap = function () {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById("map").style.backgroundImage = "none";
+
+                    // Création de la map
+                    var map = new ol.Map({
+                        layers : [
+                            new LayerWMS({
+                                layer : "ORTHOIMAGERY.ORTHOPHOTOS"
+                            })
+                        ],
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 5
+                        })
+                    });
+
+                };
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey: "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    onSuccess : createMap
+                });
+
+            });
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/ol3/Layers/pages-ol-wmts-amd-default.html
+++ b/samples-src/pages/ol3/Layers/pages-ol-wmts-amd-default.html
@@ -1,0 +1,72 @@
+{{#extend "ol-sample-amd-layout"}}
+
+{{#content "head"}}
+        <title>Sample ol3</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout d'une couche WMTS, en mode AMD</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+            requirejs(
+              [
+                "ol",
+                "gp",
+                "Ol3/Layers/LayerWMTS"
+              ],
+              function (
+                ol,
+                Gp,
+                LayerWMTS
+              ) {
+
+                var map;
+
+                /** createMap */
+                var createMap = function () {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById("map").style.backgroundImage = "none";
+
+                    // Création de la map
+                    var map = new ol.Map({
+                        layers : [
+                            new LayerWMTS({
+                                layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                            })
+                        ],
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 5
+                        })
+                    });
+
+                };
+
+                Gp.Services.getConfig({
+                    serverUrl : "{{ config.resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey: "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    onSuccess : createMap
+                });
+
+            });
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/templates/leaflet/layout-leaflet-sample-es6.hbs
+++ b/samples-src/templates/leaflet/layout-leaflet-sample-es6.hbs
@@ -8,7 +8,7 @@
         {{#block "vendor"}}
         {{/block}}
         
-        {{#extend "partials-leaflet-bundle-head"}}
+        {{#extend "partials-leaflet-es6-head"}}
         {{/extend}}
 
         {{#block "head"}}
@@ -18,7 +18,7 @@
 
     </head>
     <body>
-        <h1>Extension Géoportail pour Leaflet (mode bundle)</h1>
+        <h1>Extension Géoportail pour Leaflet (mode es6 module)</h1>
 
         {{#block "body"}}
         {{/block}}

--- a/samples-src/templates/ol3/ol-sample-es6-layout.hbs
+++ b/samples-src/templates/ol3/ol-sample-es6-layout.hbs
@@ -3,12 +3,11 @@
     <head>
         {{#extend "partials-common-head"}}
         {{/extend}}
-        {{#extend "partials-leaflet-common-head"}}
+        {{#extend "partials-ol-common-head"}}
         {{/extend}}
         {{#block "vendor"}}
         {{/block}}
-        
-        {{#extend "partials-leaflet-bundle-head"}}
+        {{#extend "partials-ol-es6-head"}}
         {{/extend}}
 
         {{#block "head"}}
@@ -18,7 +17,7 @@
 
     </head>
     <body>
-        <h1>Extension Géoportail pour Leaflet (mode bundle)</h1>
+        <h1>Extension Géoportail pour OpenLayers avec ES6 module</h1>
 
         {{#block "body"}}
         {{/block}}

--- a/samples-src/templates/partials/leaflet/partials-leaflet-es6-head.hbs
+++ b/samples-src/templates/partials/leaflet/partials-leaflet-es6-head.hbs
@@ -1,0 +1,2 @@
+        <!-- Leaflet Library -->
+        <script src="{{ config.baseurl }}/node_modules/leaflet/dist/leaflet{{ config.mode }}.js"></script>

--- a/samples-src/templates/partials/ol3/partials-ol-es6-head.hbs
+++ b/samples-src/templates/partials/ol3/partials-ol-es6-head.hbs
@@ -1,0 +1,3 @@
+        <!-- Library OpenLayers 3 -->
+        <script src="{{ config.baseurl }}/node_modules/openlayers/dist/ol.js"></script>
+        

--- a/src/Common/Utils/LayerUtils.js
+++ b/src/Common/Utils/LayerUtils.js
@@ -263,7 +263,7 @@ define([], function () {
                                 image.className = "";
                                 container.appendChild(image);
                             }
-                            image.src = logo;
+                            image.src = logo; // FIXME : mixContent ! 
                             image.title = text || name;
                             image.style.height = "30px";
                             image.style.width  = "30px";

--- a/src/Itowns/Controls/LayerSwitcher.js
+++ b/src/Itowns/Controls/LayerSwitcher.js
@@ -828,11 +828,15 @@ define([
         // visibles. Déplacement systématique des couches non visibles en couches de fond (pour ne pas occulter
         // les couches visibles).
 
+        if ( e.newIndex - e.oldIndex === 0 ) {
+            return;
+        }
+
         var targetIndex = null;
         if ( !e.newIndex || e.newIndex === 0 ) {
             targetIndex = globe.getColorLayers().length - 1;
         } else {
-            var layerTargetID  = this._resolveLayerId( e.from.childNodes[e.newIndex + (e.newIndex === e.from.childNodes.length - 1 ? -1 : 1)].id);
+            var layerTargetID  = this._resolveLayerId( e.from.childNodes[e.newIndex + (e.newIndex - e.oldIndex < 0 ? 1 : -1)].id);
             targetIndex = globe.getLayerById(layerTargetID).sequence;
         }
 

--- a/src/Itowns/GlobeViewExtended.js
+++ b/src/Itowns/GlobeViewExtended.js
@@ -252,6 +252,19 @@ define([
     };
 
     /**
+    * Get vector layers
+    *
+    * @return {Array} vector layers
+    */
+    GlobeViewExtended.prototype.getVectorLayers = function () {
+        return this.getGlobeView().getLayers( function (layer) {
+            if (layer.protocol === "rasterizer") {
+                return layer;
+            }
+        });
+    }
+
+    /**
     * Get elevation layers
     *
     * @return {Array} elevation layers
@@ -371,5 +384,133 @@ define([
         return this.getGlobeView().controls.getScale();
     };
 
-    return GlobeViewExtended;
+   /**
+    * Sets tilt
+    *
+    * @param {Number} tilt - Tilt value
+    */
+    GlobeViewExtended.prototype.setTilt = function setTilt (tilt) {
+        this.getGlobeView().controls.setTilt(tilt, false);
+    };
+
+   /**
+    * Returns tilt
+    *
+    * @return {Number} - Tilt
+    */
+    GlobeViewExtended.prototype.getTilt = function getTilt () {
+        return this.getGlobeView().controls.getCameraOrientation()[0];
+    };
+
+    /**
+    * Sets azimuth
+    *
+    * @param {Number} azimuth - Azimuth value
+     */
+    GlobeViewExtended.prototype.setAzimuth = function (azimuth) {
+        this.getGlobeView().controls.setHeading(azimuth, false);
+    };
+
+    /**
+     * Returns azimuth
+     *
+     * @return {Number} azimuth
+     */
+    GlobeViewExtended.prototype.getAzimuth = function () {
+        return this.getGlobeView().controls.getCameraOrientation()[1];
+    };
+
+   /**
+    * Gets the coordinate in lat,lon for a given pixel.
+    *
+    * @param {number | MouseEvent} mouse - The x-position inside the Globe element or a mouse event.
+    * @param {number=} y - The pixel y-position inside the Globe element.
+    * @return {Coordinates} position
+    */
+    GlobeViewExtended.prototype.getCoordinateFromPixel = function getCoordinateFromPixel (mouseEvent, y) {
+       return this.getGlobeView().controls.pickGeoPosition(mouseEvent, y);
+    };
+
+    /**
+     * Get all visible features that intersect a pixel
+     *
+     * @param {number | MouseEvent} mouse - The x-position inside the Globe element or a mouse event.
+     * @param {number=} y - The pixel y-position inside the Globe element.
+     * @return {Array} visibleFeatures - The array of visible features.
+     */
+     GlobeViewExtended.prototype.getFeaturesAtPixel = function getFeaturesAtPixel (mouseEvent, y) {
+         var vectorLayers = this.getVectorLayers();
+         if (!vectorLayers) {
+             return;
+         }
+         // array of the visible features on the clicker coord
+         var visibleFeatures = [];
+
+         var geoCoord = this.getCoordinateFromPixel(mouseEvent, y);
+         if (geoCoord) {
+             // buffer around the click inside we retrieve the features
+             var precision = this.getGlobeView().controls.pixelsToDegrees(5);
+             for (var i = 0; i < vectorLayers.length; i++) {
+                 var idx;
+                 var layer = vectorLayers[i];
+                 // if the layer is not visible, we ignore it
+                 if (!layer.visible) {
+                     continue;
+                 }
+                 var result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(geoCoord, layer.feature, precision);
+                 // we add the features to the visible features array
+                 for (idx = 0; idx < result.length; idx++) {
+                     visibleFeatures.push(result[idx]);
+                 }
+             }
+         }
+         return visibleFeatures;
+     };
+
+   /**
+    * Changes the center of the scene on screen to the specified in lat, lon.
+    *
+    * @param {Object} center
+    * @param {number}  center.longitude - Coordinate longitude WGS84 in degree
+    * @param {number}  center.latitude - Coordinate latitude WGS84 in degree
+    * @return {Array} visibleFeatures - The array of visible features.
+    */
+    GlobeViewExtended.prototype.setCameraTargetGeoPosition = function setCameraTargetGeoPosition (center) {
+        this.getGlobeView().controls.setCameraTargetGeoPositionAdvanced(center, false);
+    };
+
+    /**
+     * Retuns the coordinates of the central point on screen in lat,lon and alt
+     *
+     * @return {Object} center
+     */
+    GlobeViewExtended.prototype.getCenter = function getCenter () {
+        var cameraCenter = this.getGlobeView().controls.getCameraTargetGeoPosition();
+        var center = {
+            lon  : cameraCenter.longitude(),
+            lat  : cameraCenter.latitude(),
+            alt  : cameraCenter.altitude()
+        };
+        return center;
+    };
+
+    /**
+     * Returns the actual zoom.
+     *
+     * @return {Number} zoom
+     */
+    GlobeViewExtended.prototype.getZoom = function getZoom () {
+        return this.getGlobeView().controls.getZoom();
+    };
+
+    /**
+     * Sets the current zoom.
+     *
+     * @param {Number} zoom - The zoom
+     */
+    GlobeViewExtended.prototype.setZoom = function setZoom (zoom) {
+        this.getGlobeView().controls.setZoom(zoom,false);
+    };
+
+     return GlobeViewExtended;
 });

--- a/src/Leaflet/Layers/LayerConfig.js
+++ b/src/Leaflet/Layers/LayerConfig.js
@@ -37,12 +37,6 @@ function (woodman, Config, Util) {
                 return;
             }
 
-            // gestion de mixContent...
-            var isBrowser = typeof window !== "undefined" ? true : false;
-            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-            var _url = params.url;
-            params.url = _url.replace(/(http|https):\/\//, _protocol);
-
             // gestion des zoom
             params.minZoom = Util.getZoomLevelFromScaleDenominator(params.maxScale) || 1;
             params.maxZoom = Util.getZoomLevelFromScaleDenominator(params.minScale) || 21;

--- a/src/Leaflet/Layers/LayerConfig.js
+++ b/src/Leaflet/Layers/LayerConfig.js
@@ -37,6 +37,12 @@ function (woodman, Config, Util) {
                 return;
             }
 
+            // gestion de mixContent...
+            var isBrowser = typeof window !== "undefined" ? true : false;
+            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+            var _url = params.url;
+            params.url = _url.replace(/(http|https):\/\//, _protocol);
+
             // gestion des zoom
             params.minZoom = Util.getZoomLevelFromScaleDenominator(params.maxScale) || 1;
             params.maxZoom = Util.getZoomLevelFromScaleDenominator(params.minScale) || 21;

--- a/src/Leaflet/Layers/LayerEvent.js
+++ b/src/Leaflet/Layers/LayerEvent.js
@@ -1,9 +1,8 @@
 /**
- * desativation JSHINT
- * W106 - Identifier '_geoportal_id' is not in camel case
- */
-
- /*jshint -W106 */
+* desativation JSHINT
+* W106 - Identifier '_geoportal_id' is not in camel case
+*/
+/*jshint -W106 */
 
 define([
     "woodman",

--- a/src/Leaflet/Layers/Layers.js
+++ b/src/Leaflet/Layers/Layers.js
@@ -134,16 +134,11 @@ define([
             this._initParams("WMS");
             logger.log(this.params);
 
-            // gestion de mixContent...
-            var isBrowser = typeof window !== "undefined" ? true : false;
-            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-
             // url du service (par defaut)
             var serviceUrl = null;
             if (this.params.key || this.options.apiKey) {
-                serviceUrl = this.params.url || L.Util.template("{protocol}wxs.ign.fr/{key}/geoportail/r/wms", {
-                    key : this.params.key || this.options.apiKey,
-                    protocol : _protocol
+                serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/r/wms", {
+                    key : this.params.key || this.options.apiKey
                 });
             } else {
                 // pas d'autoconf, ni de clef API !
@@ -233,17 +228,12 @@ define([
             this._initParams("WMTS");
             logger.log(this.params);
 
-            // gestion de mixContent...
-            var isBrowser = typeof window !== "undefined" ? true : false;
-            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-
             // url du service (par defaut)
             var serviceUrl = null;
 
             if (this.params.key || this.options.apiKey) {
-                serviceUrl = this.params.url || L.Util.template("{protocol}wxs.ign.fr/{key}/geoportail/wmts", {
-                    key : this.params.key || this.options.apiKey,
-                    protocol : _protocol
+                serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/wmts", {
+                    key : this.params.key || this.options.apiKey
                 });
             } else {
                 // FIXME pas d'autoconf, ni clef API !

--- a/src/Leaflet/Layers/Layers.js
+++ b/src/Leaflet/Layers/Layers.js
@@ -134,11 +134,16 @@ define([
             this._initParams("WMS");
             logger.log(this.params);
 
+            // gestion de mixContent...
+            var isBrowser = typeof window !== "undefined" ? true : false;
+            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+
             // url du service (par defaut)
             var serviceUrl = null;
             if (this.params.key || this.options.apiKey) {
-                serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/r/wms", {
-                    key : this.params.key || this.options.apiKey
+                serviceUrl = this.params.url || L.Util.template("{protocol}wxs.ign.fr/{key}/geoportail/r/wms", {
+                    key : this.params.key || this.options.apiKey,
+                    protocol : _protocol
                 });
             } else {
                 // pas d'autoconf, ni de clef API !
@@ -228,18 +233,24 @@ define([
             this._initParams("WMTS");
             logger.log(this.params);
 
+            // gestion de mixContent...
+            var isBrowser = typeof window !== "undefined" ? true : false;
+            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+
             // url du service (par defaut)
             var serviceUrl = null;
+
             if (this.params.key || this.options.apiKey) {
-                serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/wmts", {
-                    key : this.params.key || this.options.apiKey
+                serviceUrl = this.params.url || L.Util.template("{protocol}wxs.ign.fr/{key}/geoportail/wmts", {
+                    key : this.params.key || this.options.apiKey,
+                    protocol : _protocol
                 });
             } else {
                 // FIXME pas d'autoconf, ni clef API !
                 // on évite l'exception en envoyant les requêtes vers localhost
                 serviceUrl = L.Util.template(this.serviceUrl, {
-                layer : this.options.layer
-            });
+                    layer : this.options.layer
+                });
             }
 
             // params du service WMS (par defaut)

--- a/src/Leaflet/Layers/WMS.js
+++ b/src/Leaflet/Layers/WMS.js
@@ -1,11 +1,8 @@
 /**
- * desativation JSHINT
- * W106 - Identifier '_geoportal_id' is not in camel case
- */
-
-/*jshint -W106 */
-
-/* globals self */
+* desativation JSHINT
+* W106 - Identifier '_geoportal_id' is not in camel case
+*/
+/* jshint -W106 */
 
 define([
     "leaflet",
@@ -79,16 +76,12 @@ function (L, Gp, woodman, LayerEvent) {
             var settings = {};
             L.Util.extend(settings, options.paramsWms, options.paramsNative);
 
-            // gestion de mixContent dans l'url du service...
-            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-
             // appel du constructeur de la classe étendue
             L.TileLayer.WMS.prototype.initialize.call(
                 this,
                 // tracker extension leaflet
                 // FIXME : gp-ext version en mode AMD
-                Gp.Helper.normalyzeUrl(url.replace(/(http|https):\/\//, protocol), {
+                Gp.Helper.normalyzeUrl(url, {
                     "gp-leaflet-ext" : "__GPLEAFLETEXTVERSION__"
                 }, false),
                 settings

--- a/src/Leaflet/Layers/WMS.js
+++ b/src/Leaflet/Layers/WMS.js
@@ -3,7 +3,9 @@
  * W106 - Identifier '_geoportal_id' is not in camel case
  */
 
- /*jshint -W106 */
+/*jshint -W106 */
+
+/* globals self */
 
 define([
     "leaflet",
@@ -77,12 +79,16 @@ function (L, Gp, woodman, LayerEvent) {
             var settings = {};
             L.Util.extend(settings, options.paramsWms, options.paramsNative);
 
+            // gestion de mixContent dans l'url du service...
+            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
+            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+
             // appel du constructeur de la classe étendue
             L.TileLayer.WMS.prototype.initialize.call(
                 this,
                 // tracker extension leaflet
                 // FIXME : gp-ext version en mode AMD
-                Gp.Helper.normalyzeUrl(url, {
+                Gp.Helper.normalyzeUrl(url.replace(/(http|https):\/\//, protocol), {
                     "gp-leaflet-ext" : "__GPLEAFLETEXTVERSION__"
                 }, false),
                 settings

--- a/src/Leaflet/Layers/WMTS.js
+++ b/src/Leaflet/Layers/WMTS.js
@@ -3,7 +3,9 @@
  * W106 - Identifier '_geoportal_id' is not in camel case
  */
 
- /*jshint -W106 */
+/*jshint -W106 */
+
+/* globals self */
 
 define([
     "leaflet",
@@ -94,12 +96,16 @@ function (L, Gp, woodman, LayerEvent) {
             this._wmtsParams = {};
             L.Util.extend(this._wmtsParams, this.defaultWmtsParams, options.paramsWmts);
 
+            // gestion de mixContent dans l'url du service...
+            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
+            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+
             // appel du constructeur de la classe étendue
             L.TileLayer.prototype.initialize.call(
                 this,
                 // tracker extension leaflet
                 // FIXME : gp-ext version en mode AMD
-                Gp.Helper.normalyzeUrl(url, {
+                Gp.Helper.normalyzeUrl(url.replace(/(http|https):\/\//, protocol), {
                     "gp-leaflet-ext" : "__GPLEAFLETEXTVERSION__"
                 }, false),
                 options.paramsNative

--- a/src/Leaflet/Layers/WMTS.js
+++ b/src/Leaflet/Layers/WMTS.js
@@ -1,11 +1,8 @@
 /**
- * desativation JSHINT
- * W106 - Identifier '_geoportal_id' is not in camel case
- */
-
+* desativation JSHINT
+* W106 - Identifier '_geoportal_id' is not in camel case
+*/
 /*jshint -W106 */
-
-/* globals self */
 
 define([
     "leaflet",
@@ -96,16 +93,12 @@ function (L, Gp, woodman, LayerEvent) {
             this._wmtsParams = {};
             L.Util.extend(this._wmtsParams, this.defaultWmtsParams, options.paramsWmts);
 
-            // gestion de mixContent dans l'url du service...
-            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-
             // appel du constructeur de la classe étendue
             L.TileLayer.prototype.initialize.call(
                 this,
                 // tracker extension leaflet
                 // FIXME : gp-ext version en mode AMD
-                Gp.Helper.normalyzeUrl(url.replace(/(http|https):\/\//, protocol), {
+                Gp.Helper.normalyzeUrl(url, {
                     "gp-leaflet-ext" : "__GPLEAFLETEXTVERSION__"
                 }, false),
                 options.paramsNative

--- a/src/Ol3/Layers/LayerWMS.js
+++ b/src/Ol3/Layers/LayerWMS.js
@@ -24,6 +24,7 @@ define([
      * @alias ol.layer.GeoportalWMS
      * @param {Object} options            - options for function call.
      * @param {String} options.layer      - Layer name (e.g. "ORTHOIMAGERY.ORTHOPHOTOS")
+     * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
      * @param {String} [options.apiKey]   - Access key to Geoportal platform
      * @param {Object} [options.olParams] - other options for ol.layer.Tile function (see {@link http://openlayers.org/en/latest/apidoc/ol.layer.Tile.html ol.layer.Tile})
      * @param {Object} [options.olParams.sourceParams] - other options for ol.source.TileWMS function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.TileWMS.html ol.source.TileWMS})
@@ -46,6 +47,11 @@ define([
             throw new Error("ERROR WRONG TYPE : layer");
         }
 
+        // par defaut
+        if ( typeof options.ssl === "undefined" ) {
+            options.ssl = false;
+        }
+
         // Check if configuration is loaded
         if ( !Config.isConfigLoaded() ) {
             throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers. See http://ignf.github.io/evolution-apigeoportail/ol3/ol3-autoconf.html");
@@ -58,6 +64,7 @@ define([
         }
         var wmsSource = new SourceWMS({
             layer : options.layer,
+            ssl : options.ssl,
             apiKey : options.apiKey,
             olParams : olSourceParams
         });

--- a/src/Ol3/Layers/LayerWMTS.js
+++ b/src/Ol3/Layers/LayerWMTS.js
@@ -24,6 +24,7 @@ define([
      * @alias ol.layer.GeoportalWMTS
      * @param {Object} options            - options for function call.
      * @param {String} options.layer      - Layer name (e.g. "ORTHOIMAGERY.ORTHOPHOTOS")
+     * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
      * @param {String} [options.apiKey]   - Access key to Geoportal platform
      * @param {Object} [options.olParams] - other options for ol.layer.Tile function (see {@link http://openlayers.org/en/latest/apidoc/ol.layer.Tile.html ol.layer.Tile})
      * @param {Object} [options.olParams.sourceParams] - other options for ol.source.WMTS function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.WMTS.html ol.source.WMTS})
@@ -46,6 +47,11 @@ define([
             throw new Error("ERROR WRONG TYPE : layer");
         }
 
+        // par defaut
+        if ( typeof options.ssl === "undefined" ) {
+            options.ssl = false;
+        }
+
         // Check if configuration is loaded
         if ( !Config.isConfigLoaded() ) {
             throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers. See http://ignf.github.io/evolution-apigeoportail/ol3/ol3-autoconf.html");
@@ -58,6 +64,7 @@ define([
         }
         var wmtsSource = new SourceWMTS({
             layer : options.layer,
+            ssl : options.ssl,
             apiKey : options.apiKey,
             olParams : olSourceParams
         });

--- a/src/Ol3/Layers/SourceWMS.js
+++ b/src/Ol3/Layers/SourceWMS.js
@@ -1,4 +1,4 @@
-
+/* globals self */
 define([
     "ol",
     "gp",
@@ -53,16 +53,14 @@ define([
         if ( layerId && Config.configuration.getLayerConf(layerId) ) {
             var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
-            // gestion de mixContent...
-            var isBrowser = typeof window !== "undefined" ? true : false;
-            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-            var _url = wmsParams.url;
-            wmsParams.url = _url.replace(/(http|https):\/\//, _protocol);
+            // gestion de mixContent dans l'url du service...
+            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
+            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
 
             var wmsSourceOptions = {
                 // tracker extension ol3
                 // FIXME : gp-ext version en mode AMD
-                url : Gp.Helper.normalyzeUrl(wmsParams.url,{
+                url : Gp.Helper.normalyzeUrl(wmsParams.url.replace(/(http|https):\/\//, protocol),{
                     "gp-ol3-ext" : "__GPOL3EXTVERSION__"
                 },false),
                 params : {

--- a/src/Ol3/Layers/SourceWMS.js
+++ b/src/Ol3/Layers/SourceWMS.js
@@ -22,6 +22,7 @@ define([
      * @extends {ol.source.TileWMS}
      * @param {Object} options            - options for function call.
      * @param {String} options.layer      - Layer name (e.g. "ORTHOIMAGERY.ORTHOPHOTOS")
+     * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
      * @param {String} [options.apiKey]   - Access key to Geoportal platform
      * @param {Object} [options.olParams] - other options for ol.source.TileWMS function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.TileWMS.html ol.source.TileWMS})
      * @example
@@ -43,6 +44,11 @@ define([
             throw new Error("ERROR WRONG TYPE : layer");
         }
 
+        // par defaut
+        if ( typeof options.ssl === "undefined" ) {
+            options.ssl = false;
+        }
+
         // Check if configuration is loaded
         if ( !Config.isConfigLoaded() ) {
             throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers. See http://ignf.github.io/evolution-apigeoportail/ol3/ol3-autoconf.html");
@@ -55,7 +61,9 @@ define([
 
             // gestion de mixContent dans l'url du service...
             var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+            var protocol = (ctx) ?
+                (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :
+                (options.ssl ? "https://" : "http://");
 
             var wmsSourceOptions = {
                 // tracker extension ol3

--- a/src/Ol3/Layers/SourceWMS.js
+++ b/src/Ol3/Layers/SourceWMS.js
@@ -53,12 +53,18 @@ define([
         if ( layerId && Config.configuration.getLayerConf(layerId) ) {
             var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
+            // gestion de mixContent...
+            var isBrowser = typeof window !== "undefined" ? true : false;
+            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+            var _url = wmsParams.url;
+            wmsParams.url = _url.replace(/(http|https):\/\//, _protocol);
+
             var wmsSourceOptions = {
                 // tracker extension ol3
                 // FIXME : gp-ext version en mode AMD
                 url : Gp.Helper.normalyzeUrl(wmsParams.url,{
-                          "gp-ol3-ext" : "__GPOL3EXTVERSION__"
-                      },false),
+                    "gp-ol3-ext" : "__GPOL3EXTVERSION__"
+                },false),
                 params : {
                     SERVICE : "WMS",
                     LAYERS : options.layer,

--- a/src/Ol3/Layers/SourceWMTS.js
+++ b/src/Ol3/Layers/SourceWMTS.js
@@ -1,4 +1,4 @@
-
+/* globals self */
 define([
     "ol",
     "Ol3/Sources/WMTS",
@@ -59,11 +59,9 @@ define([
 
             var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
-            // gestion de mixContent...
-            var isBrowser = typeof window !== "undefined" ? true : false;
-            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
-            var _url = wmtsParams.url;
-            wmtsParams.url = _url.replace(/(http|https):\/\//, _protocol);
+            // gestion de mixContent dans l'url du service...
+            var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
+            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
 
             // save originators (to be updated by Originators control)
             this._originators = wmtsParams.originators;
@@ -75,7 +73,7 @@ define([
             var wmtsSourceOptions = {
                 // tracker extension ol3
                 // FIXME : gp-ext version en mode AMD
-                url : Gp.Helper.normalyzeUrl(wmtsParams.url,{
+                url : Gp.Helper.normalyzeUrl(wmtsParams.url.replace(/(http|https):\/\//, protocol),{
                     "gp-ol3-ext" : "__GPOL3EXTVERSION__"
                 },false),
                 version : wmtsParams.version,

--- a/src/Ol3/Layers/SourceWMTS.js
+++ b/src/Ol3/Layers/SourceWMTS.js
@@ -28,6 +28,7 @@ define([
      * @extends {WMTSExtended}
      * @param {Object} options            - options for function call.
      * @param {String} options.layer      - Layer name (e.g. "ORTHOIMAGERY.ORTHOPHOTOS")
+     * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
      * @param {String} [options.apiKey]   - Access key to Geoportal platform
      * @param {Object} [options.olParams] - other options for ol.source.WMTS function (see {@link http://openlayers.org/en/latest/apidoc/ol.source.WMTS.html ol.source.WMTS})
      * @example
@@ -48,6 +49,12 @@ define([
         if ( typeof options.layer !== "string" ) {
             throw new Error("ERROR WRONG TYPE : layer");
         }
+
+        // par defaut
+        if ( typeof options.ssl === "undefined" ) {
+            options.ssl = false;
+        }
+        
         // Check if configuration is loaded
         if ( !Config.isConfigLoaded() ) {
             throw new Error("ERROR : contract key configuration has to be loaded to load Geoportal layers. See http://ignf.github.io/evolution-apigeoportail/ol3/ol3-autoconf.html");
@@ -61,7 +68,9 @@ define([
 
             // gestion de mixContent dans l'url du service...
             var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-            var protocol = (ctx) ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+            var protocol = (ctx) ?
+            (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :
+            (options.ssl ? "https://" : "http://");
 
             // save originators (to be updated by Originators control)
             this._originators = wmtsParams.originators;

--- a/src/Ol3/Layers/SourceWMTS.js
+++ b/src/Ol3/Layers/SourceWMTS.js
@@ -59,6 +59,12 @@ define([
 
             var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
+            // gestion de mixContent...
+            var isBrowser = typeof window !== "undefined" ? true : false;
+            var _protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
+            var _url = wmtsParams.url;
+            wmtsParams.url = _url.replace(/(http|https):\/\//, _protocol);
+
             // save originators (to be updated by Originators control)
             this._originators = wmtsParams.originators;
 
@@ -70,8 +76,8 @@ define([
                 // tracker extension ol3
                 // FIXME : gp-ext version en mode AMD
                 url : Gp.Helper.normalyzeUrl(wmtsParams.url,{
-                          "gp-ol3-ext" : "__GPOL3EXTVERSION__"
-                      },false),
+                    "gp-ol3-ext" : "__GPOL3EXTVERSION__"
+                },false),
                 version : wmtsParams.version,
                 style : wmtsParams.styles,
                 format : wmtsParams.format,

--- a/utils/template/README
+++ b/utils/template/README
@@ -1,0 +1,3 @@
+### UMD.tpl
+
+update a template UMD (Universal Module Definition) used by gulp-umd (https://www.npmjs.com/package/gulp-umd).

--- a/utils/template/UMD.tpl
+++ b/utils/template/UMD.tpl
@@ -1,0 +1,14 @@
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(<%= amd %>, factory);
+  } else if (typeof exports === 'object' && module.exports) {
+    module.exports = factory(<%= cjs %>);
+  } else if(typeof exports === 'object') {
+    exports['<%= namespace %>'] = factory(<%= cjs %>);
+  } else {
+    root.<%= namespace %> = factory(<%= global %>);
+  }
+}(typeof self !== 'undefined' ? self : this, function(<%= param %>) {
+<%= contents %>
+return <%= exports %>;
+}));


### PR DESCRIPTION
cf. issue #194 

Gestion du protocole **http|https** des extensions dites _"Layers"_...
Ceci évite des problème de **MixContent** dans les appels aux services selon si le site est hébergé en _https_ ou en _http_.

> Exemples d'utilisation des composants **Layers** (Leaflet et Openelayers)