### PR TITLE
Gestion des écouteurs lors de la suppression d'une couche...

### DIFF
--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
@@ -18,11 +18,13 @@
             <!-- map -->
             <div id="map">
             </div>
-            <button type="button" id="addMapsLayer">Ajouter une couche Maps</button>
+            <button type="button" id="addMapsLayer">Ajouter une couche Map</button>
             <br>
             <button type="button" id="addOSMLayer">Ajouter une couche OSM</button>
             <button type="button" id="modifyVisibilityOSMLayer">Visibilité sur la couche OSM</button>
             <button type="button" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
+            <button type="button" id="modifyIndexOSMLayerMin">Position (-) de la couche OSM</button>
+            <button type="button" id="modifyIndexOSMLayerMax">Position (+) de la couche OSM</button>
 {{/content}}
 
 {{#content "js"}}
@@ -84,10 +86,23 @@
                     var opacity = (osm.getOpacity() === 1.0) ? 0.5 : 1.0;
                     osm.setOpacity(opacity);
                 };
+                modifyIndexOSMLayerMin = function () {
+                    var cidx = osm.getZIndex();
+                    if (cidx === 0) {
+                        return;
+                    }
+                    osm.setZIndex(--cidx);
+                };
+                modifyIndexOSMLayerMax = function () {
+                    var cidx = osm.getZIndex();
+                    osm.setZIndex(++cidx);
+                };
                 document.getElementById("addMapsLayer").onclick = addMapsLayer;
                 document.getElementById("addOSMLayer").onclick = addOSMLayer;
                 document.getElementById("modifyVisibilityOSMLayer").onclick = modifyVisibilityOSMLayer;
                 document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
+                document.getElementById("modifyIndexOSMLayerMin").onclick = modifyIndexOSMLayerMin;
+                document.getElementById("modifyIndexOSMLayerMax").onclick = modifyIndexOSMLayerMax;
            </script>
 {{/content}}
 

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
@@ -19,7 +19,10 @@
             <div id="map">
             </div>
             <button type="button" id="addMapsLayer">Ajouter une couche Maps</button>
+            <br>
             <button type="button" id="addOSMLayer">Ajouter une couche OSM</button>
+            <button type="button" id="modifyVisibilityOSMLayer">Visibilité sur la couche OSM</button>
+            <button type="button" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
 {{/content}}
 
 {{#content "js"}}
@@ -71,17 +74,20 @@
                         // zIndex : 4,
                         opacity: 0.5
                     });
-                    map.addLayer(osm);
-                    layerSwitcher.addLayer(
-                        osm,
-                        {
-                            title : "OSM layer",
-                            description : "OSM layer"
-                        }
-                    )
+                    map.addLayer(osm); // pas d'autoconf sur une couche utilisateur donc description et nom par defaut !
+                };
+                modifyVisibilityOSMLayer = function () {
+                    var visibility = osm.getVisible();
+                    osm.setVisible(!visibility);
+                };
+                modifyOpacityOSMLayer = function () {
+                    var opacity = (osm.getOpacity() === 1.0) ? 0.5 : 1.0;
+                    osm.setOpacity(opacity);
                 };
                 document.getElementById("addMapsLayer").onclick = addMapsLayer;
                 document.getElementById("addOSMLayer").onclick = addOSMLayer;
+                document.getElementById("modifyVisibilityOSMLayer").onclick = modifyVisibilityOSMLayer;
+                document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
            </script>
 {{/content}}
 

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-addlayers.html
@@ -1,0 +1,88 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample openlayers LayerSwitcher</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du gestionnaire de couches avec formulaire d'ajout de couche</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+            <button type="button" id="addMapsLayer">Ajouter une couche Maps</button>
+            <button type="button" id="addOSMLayer">Ajouter une couche OSM</button>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                var layerSwitcher;
+                var addMapsLayer, addOSMLayer;
+                var osm, maps;
+
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+					// Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.Tile({
+                                source : new ol.source.GeoportalWMTS({
+                                    layer: "ORTHOIMAGERY.ORTHOPHOTOS"
+                                }),
+                                opacity : 0.8
+                            })
+                        ]
+                    });
+
+					// Appel du LayerSwitcher
+                    layerSwitcher = new ol.control.LayerSwitcher({});
+
+					// Ajout du LayerSwitcher à la carte
+                    map.addControl(layerSwitcher);
+                };
+
+                addMapsLayer = function() {
+                    maps = new ol.layer.Tile({
+                        source : new ol.source.GeoportalWMTS({
+                            layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                        }) // , zIndex : 0
+                    });
+                    map.addLayer(maps);
+                };
+                addOSMLayer = function() {
+                    osm = new ol.layer.Tile({
+                        source: new ol.source.OSM(),
+                        // zIndex : 4,
+                        opacity: 0.5
+                    });
+                    map.addLayer(osm);
+                    layerSwitcher.addLayer(
+                        osm,
+                        {
+                            title : "OSM layer",
+                            description : "OSM layer"
+                        }
+                    )
+                };
+                document.getElementById("addMapsLayer").onclick = addMapsLayer;
+                document.getElementById("addOSMLayer").onclick = addOSMLayer;
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
@@ -19,7 +19,11 @@
             <div id="map">
             </div>
             <button type="button" id="removeMapsLayer">Supprimer la couche carte</button>
+            <br>
             <button type="button" id="removeOSMLayer">Supprimer la couche OSM</button>
+            <button type="button" id="modifyVisibilityOSMLayer">Visibilité sur la couche OSM</button>
+            <button type="button" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
+            <br>
             <button type="button" id="removeLastLayer">Supprimer la dernière couche</button>
 
 {{/content}}
@@ -68,13 +72,23 @@
 
 					// Appel du LayerSwitcher
                     layerSwitcher = new ol.control.LayerSwitcher({
-                        layers : [{
-                            layer : osm,
-                            config : {
-                                title : "OSM",
-                                description : "description"
+                        layers : [
+                            {
+                                layer : osm,
+                                config : {
+                                    title : "OSM",
+                                    description : "description..."
+                                }
+                            },
+                            {
+                                layer : maps,
+                                config : {
+                                    title : "Carte",
+                                    description : "description..."
+                                }
                             }
-                        }]});
+                    ]
+                    });
 
 					// Ajout du LayerSwitcher à la carte
                     map.addControl(layerSwitcher);
@@ -89,14 +103,24 @@
                     }
                 };
                 removeMapsLayer = function () {
-                    layerSwitcher.removeLayer(maps);
+                    map.removeLayer(maps);
                 };
                 removeOSMLayer = function () {
-                    layerSwitcher.removeLayer(osm);
+                    map.removeLayer(osm);
+                };
+                modifyVisibilityOSMLayer = function () {
+                    var visibility = osm.getVisible();
+                    osm.setVisible(!visibility);
+                };
+                modifyOpacityOSMLayer = function () {
+                    var opacity = (osm.getOpacity() === 1.0) ? 0.5 : 1.0;
+                    osm.setOpacity(opacity);
                 };
                 document.getElementById("removeMapsLayer").onclick = removeMapsLayer;
                 document.getElementById("removeOSMLayer").onclick = removeOSMLayer;
                 document.getElementById("removeLastLayer").onclick = removeLastLayer;
+                document.getElementById("modifyVisibilityOSMLayer").onclick = modifyVisibilityOSMLayer;
+                document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
            </script>
 {{/content}}
 

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
@@ -61,13 +61,20 @@
                                 }),
                                 opacity : 0.8
                             }),
-                            maps,
-                            osm
+                            osm,
+                            maps
                         ]
                     });
 
 					// Appel du LayerSwitcher
-                    layerSwitcher = new ol.control.LayerSwitcher({});
+                    layerSwitcher = new ol.control.LayerSwitcher({
+                        layers : [{
+                            layer : osm,
+                            config : {
+                                title : "OSM",
+                                description : "description"
+                            }
+                        }]});
 
 					// Ajout du LayerSwitcher à la carte
                     map.addControl(layerSwitcher);

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
@@ -23,6 +23,8 @@
             <button type="button" id="removeOSMLayer">Supprimer la couche OSM</button>
             <button type="button" id="modifyVisibilityOSMLayer">Visibilité sur la couche OSM</button>
             <button type="button" id="modifyOpacityOSMLayer">Opacité sur la couche OSM</button>
+            <button type="button" id="modifyIndexOSMLayerMin">"Down" (-) de la couche OSM</button>
+            <button type="button" id="modifyIndexOSMLayerMax">"Up" (+) de la couche OSM</button>
             <br>
             <button type="button" id="removeLastLayer">Supprimer la dernière couche</button>
 
@@ -116,11 +118,24 @@
                     var opacity = (osm.getOpacity() === 1.0) ? 0.5 : 1.0;
                     osm.setOpacity(opacity);
                 };
+                modifyIndexOSMLayerMin = function () {
+                    var index = osm.getZIndex();
+                    if (index === 0) {
+                        return;
+                    }
+                    osm.setZIndex(--index);
+                };
+                modifyIndexOSMLayerMax = function () {
+                    var index = osm.getZIndex();
+                    osm.setZIndex(++index);
+                };
                 document.getElementById("removeMapsLayer").onclick = removeMapsLayer;
                 document.getElementById("removeOSMLayer").onclick = removeOSMLayer;
                 document.getElementById("removeLastLayer").onclick = removeLastLayer;
                 document.getElementById("modifyVisibilityOSMLayer").onclick = modifyVisibilityOSMLayer;
                 document.getElementById("modifyOpacityOSMLayer").onclick = modifyOpacityOSMLayer;
+                document.getElementById("modifyIndexOSMLayerMin").onclick = modifyIndexOSMLayerMin;
+                document.getElementById("modifyIndexOSMLayerMax").onclick = modifyIndexOSMLayerMax;
            </script>
 {{/content}}
 

--- a/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
+++ b/samples-src/pages/openlayers/LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html
@@ -1,0 +1,96 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample openlayers LayerSwitcher</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du gestionnaire de couches avec un formulaire de suppression de couches</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+            <button type="button" id="removeMapsLayer">Supprimer la couche carte</button>
+            <button type="button" id="removeOSMLayer">Supprimer la couche OSM</button>
+            <button type="button" id="removeLastLayer">Supprimer la dernière couche</button>
+
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                var layerSwitcher;
+                var removeMapsLayer, removeOSMLayer;
+                var osm, maps;
+
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    maps = new ol.layer.Tile({
+                        source : new ol.source.GeoportalWMTS({
+                            layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                        })
+                    });
+
+                    osm = new ol.layer.Tile({
+                        source: new ol.source.OSM(),
+                        // zIndex : 4,
+                        opacity: 0.5
+                    });
+
+					// Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 6
+                        }),
+                        layers : [
+                            new ol.layer.Tile({
+                                source : new ol.source.GeoportalWMTS({
+                                    layer: "ORTHOIMAGERY.ORTHOPHOTOS"
+                                }),
+                                opacity : 0.8
+                            }),
+                            maps,
+                            osm
+                        ]
+                    });
+
+					// Appel du LayerSwitcher
+                    layerSwitcher = new ol.control.LayerSwitcher({});
+
+					// Ajout du LayerSwitcher à la carte
+                    map.addControl(layerSwitcher);
+                };
+
+                removeLastLayer = function(e) {
+                    var layers = map.getLayers();
+                    var nblayers = layers.getLength();
+                    if (nblayers) {
+                        console.log("retrait de la couche ", layers.item(nblayers - 1));
+                        map.getLayers().removeAt(nblayers - 1);
+                    }
+                };
+                removeMapsLayer = function () {
+                    layerSwitcher.removeLayer(maps);
+                };
+                removeOSMLayer = function () {
+                    layerSwitcher.removeLayer(osm);
+                };
+                document.getElementById("removeMapsLayer").onclick = removeMapsLayer;
+                document.getElementById("removeOSMLayer").onclick = removeOSMLayer;
+                document.getElementById("removeLastLayer").onclick = removeLastLayer;
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -325,9 +325,23 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     if (!layer) {
         return;
     }
-    // FIXME
-    // cette methode fait elle correctement le job ?
-    this.getMap().removeLayer(layer);
+
+    layer.un(
+        "change:opacity",
+        this._updateLayerOpacity,
+        this
+    );
+    layer.un(
+        "change:visible",
+        this._updateLayerVisibility,
+        this
+    );
+    layer.un(
+        "change:zIndex",
+        this._updateLayersOrder,
+        this
+    );
+
     logger.trace(layer);
 
     var layerID = layer.gpLayerId;
@@ -755,7 +769,9 @@ LayerSwitcher.prototype._updateLayerVisibility = function (e) {
     var visible = e.target.getVisible();
     var id = e.target.gpLayerId;
     var layerVisibilityInput = document.getElementById(this._addUID("GPvisibility_ID_" + id));
-    layerVisibilityInput.checked = visible;
+    if (layerVisibilityInput) {
+        layerVisibilityInput.checked = visible;
+    }
 };
 
 /**

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -322,6 +322,9 @@ LayerSwitcher.prototype.addLayer = function (layer, config) {
  * @param {ol.layer.Layer} layer - layer.
  */
 LayerSwitcher.prototype.removeLayer = function (layer) {
+    if (!layer) {
+        return;
+    }
     var layerID = layer.gpLayerId;
     var layerList = document.getElementById(this._addUID("GPlayersList"));
     // close layer info element if open.
@@ -332,7 +335,9 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     }
     // remove layer div
     var layerDiv = document.getElementById(this._addUID("GPlayerSwitcher_ID_" + layerID));
-    layerList.removeChild(layerDiv);
+    if (layerDiv) {
+        layerList.removeChild(layerDiv);
+    }
 
     var layerIndex = Math.abs(layer.getZIndex() - this._lastZIndex);
     // on retire la couche de la liste ordonnée des layers
@@ -345,6 +350,26 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     }
     // on retire la couche de la liste des layers
     delete this._layers[layerID];
+
+    // on supprime le layer et ses ecouteurs !
+    layer.un(
+        "change:opacity",
+        this._updateLayerOpacity,
+        this
+    );
+
+    layer.un(
+        "change:visible",
+        this._updateLayerVisibility,
+        this
+    );
+
+    // FIXME zindex ?
+    // layer.un("change:zIndex");
+
+    // FIXME
+    // cette methode fait elle correctement le job ?
+    this.getMap().getLayers().remove(layer);
 };
 
 /**
@@ -709,10 +734,16 @@ LayerSwitcher.prototype._updateLayerOpacity = function (e) {
         opacity = 0;
     }
     var id = e.target.gpLayerId;
+
     var layerOpacityInput = document.getElementById(this._addUID("GPopacityValueDiv_ID_" + id));
-    layerOpacityInput.value = Math.round(opacity * 100);
+    if (layerOpacityInput) {
+        layerOpacityInput.value = Math.round(opacity * 100);
+    }
+
     var layerOpacitySpan = document.getElementById(this._addUID("GPopacityValue_ID_" + id));
-    layerOpacitySpan.innerHTML = Math.round(opacity * 100) + "%";
+    if (layerOpacitySpan) {
+        layerOpacitySpan.innerHTML = Math.round(opacity * 100) + "%";
+    }
 };
 
 /**

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -325,6 +325,11 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     if (!layer) {
         return;
     }
+    // FIXME
+    // cette methode fait elle correctement le job ?
+    this.getMap().removeLayer(layer);
+    logger.trace(layer);
+
     var layerID = layer.gpLayerId;
     var layerList = document.getElementById(this._addUID("GPlayersList"));
     // close layer info element if open.
@@ -350,11 +355,6 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     }
     // on retire la couche de la liste des layers
     delete this._layers[layerID];
-
-    // FIXME
-    // cette methode fait elle correctement le job ?
-    this.getMap().removeLayer(layer);
-    logger.trace(layer);
 };
 
 /**

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -351,25 +351,10 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
     // on retire la couche de la liste des layers
     delete this._layers[layerID];
 
-    // on supprime le layer et ses ecouteurs !
-    layer.un(
-        "change:opacity",
-        this._updateLayerOpacity,
-        this
-    );
-
-    layer.un(
-        "change:visible",
-        this._updateLayerVisibility,
-        this
-    );
-
-    // FIXME zindex ?
-    // layer.un("change:zIndex");
-
     // FIXME
     // cette methode fait elle correctement le job ?
-    this.getMap().getLayers().remove(layer);
+    this.getMap().removeLayer(layer);
+    logger.trace(layer);
 };
 
 /**

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -320,6 +320,7 @@ LayerSwitcher.prototype.addLayer = function (layer, config) {
  * Remove a layer from control
  *
  * @param {ol.layer.Layer} layer - layer.
+ * @deprecated on the future version ...
  */
 LayerSwitcher.prototype.removeLayer = function (layer) {
     if (!layer) {
@@ -336,6 +337,7 @@ LayerSwitcher.prototype.removeLayer = function (layer) {
         this._updateLayerVisibility,
         this
     );
+    // FIXME !?
     layer.un(
         "change:zIndex",
         this._updateLayersOrder,


### PR DESCRIPTION
cf. issue #201 

Lors de la suppression d'une couche 

> map.removeLayer(layer)

la couche doit être supprimé du contrôle et de la carte.
Et les écouteurs (**opacity** + **visisbility** + **zIndex**) doivent être aussi supprimés.

**FIXME** 
> l'écouteur **zindex** ne semble pas être supprimé ?

Pour tester les modifications, on utilise l'exemple suivant : 
**LayerSwitcher/pages-ol-layerswitcher-bundle-removelayers.html**
et, ouvrir la console afin de voir si des exceptions sont lancées et mettre des points d'arrêts dans les sources sur les gestionnaires des listeners (ex. _updateLayerVisibility)...
