### PR TITLE
Structurer l'import des couches WMS en rubrique

### DIFF
--- a/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
+++ b/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
@@ -220,12 +220,12 @@ input[id^="GPimportGetCapRubrique-"] ~ li {
 input[id^="GPimportGetCapRubrique-"]:checked ~ li {
  display: block;
 }
-/* input[id^="GPimportGetCapRubrique-"] ~ ul {
+input[id^="GPimportGetCapRubrique-"] ~ ul {
  display: block;
 }
 input[id^="GPimportGetCapRubrique-"]:checked ~ ul {
  display: none;
-} */
+}
 
 .GPimportGetCapProposal {
   width: 100%;

--- a/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
+++ b/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
@@ -240,7 +240,30 @@ input[id^="GPimportGetCapRubrique-"]:checked ~ ul {
   cursor: pointer;
 }
 
+.GPimportGetCapRubriqueTitle {
+    color: #5E5E5E;
+}
+
+.GPimportGetCapRubrique,
+.GPimportGetCapListRubrique {
+    list-style-type: none;
+}
+
+li.GPimportGetCapRubrique:before,
+li.GPimportGetCapListRubrique:before {
+	/* content: "→ "; caractère UTF-8 */
+    content: "» ";
+}
+
+.GPimportGetCapProposal:hover,
+.GPimportGetCapRubrique:hover {
+
+}
+
+.GPimportGetCapRubriqueTitle:hover {
+    color: #000000;
+}
+
 .GPimportGetCapProposal:hover {
   color: #000000;
-  background-color: #CEDBEF
 }

--- a/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
+++ b/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
@@ -238,6 +238,7 @@ input[id^="GPimportGetCapRubrique-"]:checked ~ ul {
   white-space: nowrap;
   text-overflow:ellipsis;
   cursor: pointer;
+  list-style-type: none;
 }
 
 .GPimportGetCapRubriqueTitle {

--- a/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
+++ b/res/OpenLayers/Controls/LayerImport/GPimportOpenLayers.css
@@ -211,6 +211,22 @@ div[id^="GPimportGetCapResults-"] {
   overflow-y: auto;
 }
 
+input[id^="GPimportGetCapRubrique-"] {
+  display: none;
+}
+input[id^="GPimportGetCapRubrique-"] ~ li {
+ display: none;
+}
+input[id^="GPimportGetCapRubrique-"]:checked ~ li {
+ display: block;
+}
+/* input[id^="GPimportGetCapRubrique-"] ~ ul {
+ display: block;
+}
+input[id^="GPimportGetCapRubrique-"]:checked ~ ul {
+ display: none;
+} */
+
 .GPimportGetCapProposal {
   width: 100%;
   height: 28px;

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-cors-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-cors-proxy.html
@@ -50,11 +50,9 @@
                 });
                 map.addControl(layerImport);
 
-                var layerSwitcher = new ol.control.LayerSwitcher({});
-                map.addControl(layerSwitcher);
-
                 var input = document.querySelector("input[id^=GPimportServiceUrl-]");
-                input.value = "http://wxs-gpu.mongeoportail.ign.fr/externe/vkd1evhid6jdj5h4hkhyzjto/wms/v";
+                input.value = "http://carto.atlasante.fr/cgi-bin/mapserv";
+                // input.value = "http://wxs-gpu.mongeoportail.ign.fr/externe/vkd1evhid6jdj5h4hkhyzjto/wms/v";
               };
 
             </script>

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-proxy.html
@@ -45,13 +45,14 @@
                     collapsed : false,
                     layerTypes : ["WMS"],
                     webServicesOptions : {
-                        proxyUrl : "https://localhost/proxy/proxy.php?url="
+                        proxyUrl : "http://localhost/proxy/proxy.php?url="
                     }
                 });
                 map.addControl(layerImport);
 
                 var input = document.querySelector("input[id^=GPimportServiceUrl-]");
                 input.value = "http://carto.atlasante.fr/cgi-bin/mapserv";
+                // input.value = "http://wxs-gpu.mongeoportail.ign.fr/externe/vkd1evhid6jdj5h4hkhyzjto/wms/v";
               };
 
             </script>

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-proxy.html
@@ -1,0 +1,59 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample openlayers LayerImport</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du widget d'import de couches, avec l'option proxyUrl sur un service WMS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+
+              window.onload = function () {
+                // on cache l'image de chargement du Géoportail.
+                document.getElementById("map").style.backgroundImage = "none";
+
+                // Création de la map
+                var map = new ol.Map({
+                  target : "map",
+                  layers : [
+                    new ol.layer.GeoportalWMTS({
+                      layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                    })
+                  ],
+                  view : new ol.View({
+                    center : [288074.8449901076, 6247982.515792289],
+                    zoom : 8
+                  })
+                });
+
+                var layerImport = new ol.control.LayerImport({
+                    collapsed : false,
+                    layerTypes : ["WMS"],
+                    webServicesOptions : {
+                        proxyUrl : "https://localhost/proxy/proxy.php?url="
+                    }
+                });
+                map.addControl(layerImport);
+
+                var input = document.querySelector("input[id^=GPimportServiceUrl-]");
+                input.value = "http://carto.atlasante.fr/cgi-bin/mapserv";
+              };
+
+            </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
@@ -45,7 +45,7 @@
                     collapsed : false,
                     layerTypes : ["WMTS"],
                     webServicesOptions : {
-                        proxyUrl : "http://localhost/proxy/proxy.php?url="
+                        proxyUrl : "{{ resources }}/proxy/proxy.php?url="
                     }
                 });
                 map.addControl(layerImport);

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
@@ -45,7 +45,7 @@
                     collapsed : false,
                     layerTypes : ["WMTS"],
                     webServicesOptions : {
-                        proxyUrl : "https://localhost/proxy/proxy.php?url="
+                        proxyUrl : "http://localhost/proxy/proxy.php?url="
                     }
                 });
                 map.addControl(layerImport);

--- a/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
+++ b/samples-src/pages/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html
@@ -1,0 +1,59 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample openlayers LayerImport</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du widget d'import de couches, avec l'option proxyUrl sur un service WMTS</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+
+              window.onload = function () {
+                // on cache l'image de chargement du Géoportail.
+                document.getElementById("map").style.backgroundImage = "none";
+
+                // Création de la map
+                var map = new ol.Map({
+                  target : "map",
+                  layers : [
+                    new ol.layer.GeoportalWMTS({
+                      layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                    })
+                  ],
+                  view : new ol.View({
+                    center : [288074.8449901076, 6247982.515792289],
+                    zoom : 8
+                  })
+                });
+
+                var layerImport = new ol.control.LayerImport({
+                    collapsed : false,
+                    layerTypes : ["WMTS"],
+                    webServicesOptions : {
+                        proxyUrl : "https://localhost/proxy/proxy.php?url="
+                    }
+                });
+                map.addControl(layerImport);
+
+                var input = document.querySelector("input[id^=GPimportServiceUrl-]");
+                input.value = "http://wxs.ign.fr/jhyvi0fgmnuxvfv0zjzorvdn/geoportail/wmts?";
+              };
+
+            </script>
+{{/content}}
+{{/extend}}

--- a/samples-src/resources/proxy/proxy.php
+++ b/samples-src/resources/proxy/proxy.php
@@ -1,0 +1,204 @@
+<?php
+// proxy http
+// auteur: Marc Gauthier
+// 02/09/2009
+// les erreurs dans les log du serveur
+// http://www.papygeek.com/download/53/
+// Transfer-Encoding: chunked
+//
+// Didier Richard - IGN - dérivation pour publication
+// (c) IGN 2010
+// License : http://creativecommons.org/licenses/by-nc-sa/2.0/fr/
+
+    // ----------------------------------------------------------
+    // global variables :
+    $debug= 0;
+    $debug_html= 0;
+    $sUrl= '';
+    $sReponse= '';
+    // via un proxy d'entreprise/IP
+    //$proxy_host= 'proxy.ign.fr';
+    //$proxy_port= 3128;
+    $content_types= array(
+        'application/vnd.google-earth.kml+xml',
+        'application/vnd.google-earth.kml',
+        //'application/vnd.google-earth.kmz', # TODO needs to unzip response ...
+        'application/vnd.ogc.se_xml',
+        'application/vnd.ogc.wms_xml',
+        'application/vnd.ogc.wfs_xml',
+        'application/vnd.ogc.gml',
+        'application/soap+xml',
+        'application/xml',
+        'text/xml',
+        'application/json', # allow JSON
+        'text/json',
+        'application/x-javascript', # allow javascript
+        'text/plain',
+        'text/html');
+    // ----------------------------------------------------------
+
+    //
+    // écriture d'un message de log
+    function carp($msg) {
+        global $debug;
+        global $debug_html;
+        if ($debug) {
+            if ($debug_html) {
+                print "__FILE__.:$msg.<br>\n";
+            }
+            error_log(__FILE__.": $msg", 0);
+        }
+    }
+
+    //
+    // écriture d'un message de log et erreur http
+    function confess($msg) {
+        carp($msg);
+        header("HTTP/1.0 500 $msg");
+        exit;
+    }
+
+    //
+    // mode chunk
+    function unchunk($result) {
+        return preg_replace_callback(
+            '/(?:(?:\r\n|\n)|^)([0-9A-F]+)(?:\r\n|\n){1,2}(.*?)'.
+            '((?:\r\n|\n)(?:[0-9A-F]+(?:\r\n|\n))|$)/si',
+            create_function(
+                '$matches',
+                'return hexdec($matches[1]) == strlen($matches[2]) ? $matches[2] : $matches[0];'
+            ),
+            $result
+        );
+    }
+
+    //
+    // la fonction proxy
+    // 2 grandes étapes:
+    // - émission de la requête
+    // - réception de la réponse
+    function proxy($sUrl) {
+        global $proxy_host, $proxy_port, $chunked, $content_types;
+        //
+        // analyse de l'url et construction de la requête
+        $sUrl= urldecode($sUrl);
+        $referrer= (isset($_SERVER["HTTP_REFERER"])? $_SERVER["HTTP_REFERER"] : "");
+        $userAgent= (isset($_SERVER["HTTP_USER_AGENT"])? $_SERVER["HTTP_USER_AGENT"] : "");
+        $aUrl= @parse_url($sUrl);
+        if (!isset($aUrl['scheme'])) {
+            //try absolute and relative path:
+            confess("proxy scheme missing");
+        }
+        // construction de la requete
+        $acceptH= (isset($_SERVER['HTTP_ACCEPT'])? $_SERVER['HTTP_ACCEPT'] : "");
+        #$pragmaH= (isset($_SERVER['HTTP_PRAGMA'])? $_SERVER['HTTP_PRAGMA'] : "");
+        #$cacheControlH= (isset($_SERVER['HTTP_CACHE_CONTROL'])? $_SERVER['HTTP_CACHE_CONTROL'] : "");
+        $acceptLanguageH= (isset($_SERVER['HTTP_ACCEPT_CHARSET'])? $_SERVER['HTTP_ACCEPT_CHARSET'] : "");
+        $keepAliveH= (isset($_SERVER['HTTP_KEEP_ALIVE'])? $_SERVER['HTTP_KEEP_ALIVE'] : "");
+        #$acceptEncodingH= (isset($_SERVER['HTTP_ACCEPT_ENCODING'])? $_SERVER['HTTP_ACCEPT_ENCODING'] : "");//TODO decompression
+        #$connectionH= (isset($_SERVER['HTTP_CONNECTION'])? $_SERVER['HTTP_CONNECTION'] : "");
+        #$SOAPActionH= (isset($_SERVER['HTTP_SOAPACTION'])? $_SERVER['HTTP_SOAPACTION'] : "");
+        $acceptCharsetH= (isset($_SERVER['HTTP_ACCEPT_CHARSET'])? $_SERVER['HTTP_ACCEPT_CHARSET'] : "");
+        #$gppKeyH= (isset($_SERVER['gppkey'];#if gppKey in HTTP Header
+        $Hs= "Host: ".$aUrl['host'].(isset($aUrl['port']) && !empty($aUrl['port']) ? ":".$aUrl['port'] : "")."\r\n"
+            . (strlen($acceptH)>0? "Accept: ".$acceptH : join(",", $content_types))."\r\n"
+            #. (strlen($pragmaH)>0? "Pragma: ".$pragmaH."\r\n" : "")
+            #. (strlen($cacheControlH)>0? "Cache-Control: ".$cacheControlH."\r\n" : "")
+            . (strlen($acceptLanguageH)>0? "Accept-Language: ".$acceptLanguageH."\r\n" : "")
+            . (strlen($keepAliveH)>0? "Keep-Alive: ".$keepAliveH."\r\n" : "")
+            #. (strlen($acceptEncodingH)>0? "Accept-Encoding: ".$acceptEncodingH."\r\n" : "")
+            #. (strlen($connectionH)>0? "Connection: ".$connectionH."\r\n" : "")
+            #. (strlen($SOAPActionH)>0? "SOAPAction: ".$SOAPActionH."\r\n" : "")
+            . (strlen($acceptCharsetH)>0? "Accept-Charset: ".$acceptCharsetH."\r\n" : "")
+            #. (strlen($gppKeyH)>0? "gppkey: ".$gppKeyH."\r\n" : "")
+            . (strlen($referrer)>0? "Referer: ".$referrer."\r\n" : "")
+            . (strlen($userAgent)>0? "User-Agent: ".$userAgent."\r\n" : "")
+            ;
+        carp($Hs);
+        if ($_SERVER["REQUEST_METHOD"]==='GET') {
+            $sReq= "GET $sUrl HTTP/1.0\r\n"
+                 . $Hs
+                 ;
+        } else {
+            if ($_SERVER["REQUEST_METHOD"]==='POST') {
+                $data= '';
+                if (count($_POST)){
+                    while (list($key, $val)= each($_POST)){
+                        $data.="$key : $val\n";
+                    }
+                } else {
+                    $data= trim(file_get_contents('php://input'));
+                }
+                $sReq= "POST $sUrl HTTP/1.0\r\n"
+                     . $Hs
+                     . "Content-Type: text/xml\r\n"
+                     . "Content-length: ".strlen($data)."\r\n"
+                     . "\r\n"
+                     . $data
+                     ;
+            }
+        }
+        $sReq.= "\r\n";
+        if (empty($proxy_host)) {
+            $host= $aUrl["host"];
+            $port= (isset($aUrl["port"]) && !empty($aUrl["port"])? $aUrl["port"] : 80);
+        } else {
+            $host= $proxy_host;
+            $port= $proxy_port;
+        }
+        // envoi de la requête
+        carp("host:$host port:$port url:$sUrl");
+        $fp= @fsockopen($host, $port, $errno, $errstr, 30);
+        if (!$fp) {
+            confess("fsockopen failed: $errstr ($errno)");
+        }
+        carp("sReq:$sReq");
+        fwrite($fp, $sReq);
+        // attente de la réponse
+        $headers= '';
+        $sReponse= '';
+        ob_start();
+        while (!feof($fp)) {
+            $sReponse.= fread($fp, 4096);
+        }
+        fclose ($fp);
+        $eoh= strpos($sReponse, "\r\n\r\n");
+        $headers= substr($sReponse, 0, $eoh);
+        $sReponse= substr($sReponse, $eoh+4);
+        $Hs= preg_split('/(?:\r\n|\n)/', $headers);
+        carp("Hs=[".count($Hs)."]");
+        for ($i= 0, $l= count($Hs); $i<$l; $i++) {
+            if (preg_match('/^Content-Length/i', $Hs[$i])) {
+                continue;
+            }
+            if (preg_match('/^Transfer-Encoding: chunked/i', $Hs[$i])) {
+                // Transfer-Encoding: chunked
+                carp("chunked response");
+                $sReponse= unchunck($sReponse);
+                continue;
+            }
+            #carp("header=[$Hs[$i]]");
+            header($Hs[$i]);
+        }
+        header("Content-Length: ".strlen($sReponse));
+        print $sReponse;
+    }
+
+    // ----------------------------------------------------------
+    // programme principal:
+    // on accept que GET/POST (pour l'instant)
+    if (($_SERVER["REQUEST_METHOD"]==='GET' or $_SERVER["REQUEST_METHOD"]==='POST') &&
+        (isset($_REQUEST["url"]) && strlen($_REQUEST["url"])>0)) {
+        $sUrl= substr($_SERVER["QUERY_STRING"],4);
+        carp("Proxying:$sUrl");
+        proxy($sUrl);
+        exit;
+    }
+    // on ne traite pas la demande :
+    carp("REQUEST_METHOD:".$_SERVER["REQUEST_METHOD"]." QUERY_STRING:".$_SERVER["QUERY_STRING"] );
+    if ($debug) {
+        phpinfo(INFO_VARIABLES);
+    }
+    exit;
+    // ----------------------------------------------------------
+?>

--- a/src/Common/Controls/LayerImportDOM.js
+++ b/src/Common/Controls/LayerImportDOM.js
@@ -648,16 +648,16 @@ var LayerImportDOM = {
         return container;
     },
 
-    _addImportGetCapResultListRubrique : function (description, container) {
+    _addImportGetCapResultListRubrique : function (title, container) {
         var ul = document.createElement("ul");
         ul.className = "GPimportGetCapListRubrique";
-        ul.title = description;
+        ul.title = title;
 
         container.appendChild(ul);
         return container;
     },
 
-    _addImportGetCapResultRubrique : function (description, container) {
+    _addImportGetCapResultRubrique : function (title, container) {
         var li = document.createElement("li");
         li.className = "GPimportGetCapRubrique";
 
@@ -668,14 +668,12 @@ var LayerImportDOM = {
         input.type = "checkbox";
         li.appendChild(input);
 
-        // TODO picto
-
         // label for
         var label = document.createElement("label");
         label.className = "GPimportGetCapRubriqueTitle";
         label.htmlFor = input.id;
-        label.innerHTML = description;
-        label.title = description;
+        label.innerHTML = title;
+        label.title = title;
         li.appendChild(label);
 
         container.appendChild(li);
@@ -693,8 +691,8 @@ var LayerImportDOM = {
     _addImportGetCapResultLayer : function (description, id, container) {
         var li = document.createElement("li");
         li.className = "GPimportGetCapProposal";
-        li.innerHTML = description;
-        li.title = description;
+        li.innerHTML = description.content;
+        li.title = description.title;
         li.id = "GPimportGetCapProposal_" + id;
 
         var context = this;

--- a/src/Common/Controls/LayerImportDOM.js
+++ b/src/Common/Controls/LayerImportDOM.js
@@ -1,3 +1,5 @@
+import SelectorID from "../Utils/SelectorID";
+
 var LayerImportDOM = {
 
     /**
@@ -638,38 +640,76 @@ var LayerImportDOM = {
      *
      * @returns {DOMElement} DOM element
      */
-    _createImportGetCapResultsListElement : function () {
+    _createImportGetCapResultsContainer : function () {
         var container = document.createElement("div");
+        container.className = "GPimportGetCapRoot";
         container.id = this._addUID("GPimportGetCapResults");
+
         return container;
     },
 
-    /**
-     * Create GetCap Result Element ( = layer description)
-     *
-     * @param {String} layerDescription - description to be displayed for layer
-     * @param {Number} id - layer identifier in getCapabilities response layers list
-     * @returns {DOMElement} DOM element
-     */
-    _createImportGetCapResultElement : function (layerDescription, id) {
-        var div = document.createElement("div");
-        div.className = "GPimportGetCapProposal";
-        div.innerHTML = layerDescription;
-        div.title = layerDescription;
+    _addImportGetCapResultListRubrique : function (description, container) {
+        var ul = document.createElement("ul");
+        ul.className = "GPimportGetCapListRubrique";
+        ul.title = description;
+
+        container.appendChild(ul);
+        return container;
+    },
+
+    _addImportGetCapResultRubrique : function (description, container) {
+        var li = document.createElement("li");
+        li.className = "GPimportGetCapRubrique";
+
+        // input
+        var input = document.createElement("input");
+        input.id = "GPimportGetCapRubrique-" + SelectorID.generate();
+        input.className = "GPimportGetCapRubrique";
+        input.type = "checkbox";
+        li.appendChild(input);
+
+        // TODO picto
+
+        // label for
+        var label = document.createElement("label");
+        label.className = "GPimportGetCapRubriqueTitle";
+        label.htmlFor = input.id;
+        label.innerHTML = description;
+        label.title = description;
+        li.appendChild(label);
+
+        container.appendChild(li);
+        return container;
+    },
+
+    _addImportGetCapResultListLayer : function (container) {
+        var ul = document.createElement("ul");
+        ul.className = "GPimportGetCapListLayer";
+
+        container.appendChild(ul);
+        return container;
+    },
+
+    _addImportGetCapResultLayer : function (description, id, container) {
+        var li = document.createElement("li");
+        li.className = "GPimportGetCapProposal";
+        li.innerHTML = description;
+        li.title = description;
+        li.id = "GPimportGetCapProposal_" + id;
 
         var context = this;
-        if (div.addEventListener) {
-            div.addEventListener("click", function (e) {
+        if (li.addEventListener) {
+            li.addEventListener("click", function (e) {
                 context._onGetCapResponseLayerClick(e);
             });
-        } else if (div.attachEvent) {
-            div.attachEvent("onclick", function () {
+        } else if (li.attachEvent) {
+            li.attachEvent("onclick", function () {
                 context._onGetCapResponseLayerClick();
             });
         }
-        div.id = "GPimportGetCapProposal_" + id;
 
-        return div;
+        container.appendChild(li);
+        return container;
     }
 
 };

--- a/src/OpenLayers/Controls/LayerImport.js
+++ b/src/OpenLayers/Controls/LayerImport.js
@@ -1082,7 +1082,10 @@ LayerImport.prototype._importServiceLayers = function () {
 LayerImport.prototype._displayGetCapResponseLayers = function (xmlResponse) {
     var parser;
     var layers;
-    var layerDescription;
+    var layerDescription = {
+        content : null,
+        title : null
+    };
     var projection;
     this._getCapResponseWMSLayers = [];
 
@@ -1141,7 +1144,10 @@ LayerImport.prototype._displayGetCapResponseLayers = function (xmlResponse) {
                         if (ol.proj.get(projection) || ol.proj.get(projection.toUpperCase())) {
                             // si la projection de la couche est connue par ol.proj,
                             // on ajoute chaque couche de la réponse dans la liste des couches accessibles
-                            layerDescription = layers[j].Title;
+                            layerDescription = {
+                                content : layers[j].Title,
+                                title : layers[j].Abstract || layers[j].Title
+                            };
                             if (this._getCapResultsListContainer) {
                                 this._addImportGetCapResultLayer(layerDescription, j, this._getCapResultsListContainer);
                             }
@@ -1176,7 +1182,10 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
     // récupération de la projection de la map (pour vérifier que l'on peut reprojeter les couches disponibles)
     var mapProjCode = this._getMapProjectionCode();
     var projection;
-    var layerDescription;
+    var layerDescription = {
+        content : null,
+        title : null
+    };
 
     // 1. héritage éventuels des informations de la couche parent
     if (parentLayersInfos) {
@@ -1276,7 +1285,10 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
             // si on a une projection compatible : on la stocke et la couche sera éventuellement reprojetée à l'ajout
             layerObj._projection = projection;
             // on ajoute chaque couche de la réponse dans la liste des couches accessibles
-            layerDescription = layerObj.Title;
+            layerDescription = {
+                content : layerObj.Title,
+                title : layerObj.Abstract || layerObj.Title
+            };
             // FIXME beurk !?
             var _isGoodContainer = layerObj._container;
             if (_isGoodContainer.localName === "ul") {

--- a/src/OpenLayers/Controls/LayerImport.js
+++ b/src/OpenLayers/Controls/LayerImport.js
@@ -54,7 +54,7 @@ var logger = Logger.getLogger("layerimport");
  *                       width : 7
  *                  }),
  *                  fill : new ol.style.Fill({
- *                       color : "rgba(255, 183, 152, 0.2)""
+ *                       color : "rgba(255, 183, 152, 0.2)"
  *                  }),
  *                  text : new ol.style.Text({
  *                      font : "16px Sans",
@@ -175,7 +175,7 @@ LayerImport.prototype.getCollapsed = function () {
  */
 LayerImport.prototype.setCollapsed = function (collapsed) {
     if (collapsed === undefined) {
-        logger.log("[ERROR] LayerImport:setCollapsed - missing collapsed parameter");
+        logger.error("[ERROR] LayerImport:setCollapsed - missing collapsed parameter");
         return;
     }
     if ((collapsed && this.collapsed) || (!collapsed && !this.collapsed)) {
@@ -354,7 +354,7 @@ LayerImport.prototype._checkInputOptions = function (options) {
         var layerTypes = options.layerTypes;
         // on vérifie que la liste des types est bien un tableau
         if (!Array.isArray(layerTypes)) {
-            logger.log("[ol.control.LayerImport] 'options.layerTypes' parameter should be an array. Set default values [\"KML\", \"GPX\", \"GeoJSON\", \"WMS\", \"WMTS\"]");
+            logger.warn("[ol.control.LayerImport] 'options.layerTypes' parameter should be an array. Set default values [\"KML\", \"GPX\", \"GeoJSON\", \"WMS\", \"WMTS\"]");
             options.layerTypes = [
                 "KML",
                 "GPX",
@@ -376,7 +376,7 @@ LayerImport.prototype._checkInputOptions = function (options) {
                 if (typeof layerTypes[i] !== "string") {
                     // si l'élément du tableau n'est pas une chaine de caractères, on stocke l'index pour le retirer du tableau
                     wrongTypesIndexes.push(i);
-                    logger.log("[ol.control.LayerImport] 'options.layerTypes' elements should be of type string (" + layerTypes[i] + ")");
+                    logger.warn("[ol.control.LayerImport] 'options.layerTypes' elements should be of type string (" + layerTypes[i] + ")");
                 } else {
                     // on passe en majuscules pour comparer
                     layerTypes[i] = layerTypes[i].toUpperCase();
@@ -484,7 +484,7 @@ LayerImport.prototype._initContainer = function () {
     // results (dans le panel)
     var getCapPanel = this._getCapPanel = this._createImportGetCapPanelElement();
     getCapPanel.appendChild(this._createImportGetCapPanelHeaderElement());
-    var importGetCapResultsList = this._getCapResultsListContainer = this._createImportGetCapResultsListElement();
+    var importGetCapResultsList = this._getCapResultsListContainer = this._createImportGetCapResultsContainer();
     getCapPanel.appendChild(importGetCapResultsList);
 
     container.appendChild(getCapPanel);
@@ -697,7 +697,7 @@ LayerImport.prototype._importStaticLayerFromUrl = function (layerName) {
     var url = this._staticUrlImportInput.value;
     logger.log("url : ", url);
     if (url.length === 0) {
-        logger.log("[ol.control.LayerImport] url parameter is mandatory");
+        logger.error("[ol.control.LayerImport] url parameter is mandatory");
         return;
     }
     // on supprime les éventuels espaces avant ou après
@@ -707,7 +707,7 @@ LayerImport.prototype._importStaticLayerFromUrl = function (layerName) {
 
     // 2. récupération proxy
     if (!this.options.webServicesOptions || (!this.options.webServicesOptions.proxyUrl && !this.options.webServicesOptions.noProxyDomains)) {
-        logger.log("[ol.control.LayerImport] options.webServicesOptions.proxyUrl parameter is mandatory to request resources on another domain (cross-domain)");
+        logger.error("[ol.control.LayerImport] options.webServicesOptions.proxyUrl parameter is mandatory to request resources on another domain (cross-domain)");
         return;
     };
     url = ProxyUtils.proxifyUrl(url, this.options.webServicesOptions);
@@ -730,7 +730,7 @@ LayerImport.prototype._importStaticLayerFromUrl = function (layerName) {
         onFailure : function (error) {
             // en cas d'erreur, on revient au panel initial et on cache la patience
             context._hideWaitingContainer();
-            logger.log("[ol.control.LayerImport] KML/GPX/GeoJSON request failed : ", error);
+            logger.error("[ol.control.LayerImport] KML/GPX/GeoJSON request failed : ", error);
         }
     });
 };
@@ -745,7 +745,7 @@ LayerImport.prototype._importStaticLayerFromUrl = function (layerName) {
 LayerImport.prototype._importStaticLayerFromLocalFile = function (layerName) {
     var file = this._staticLocalImportInput.files[0];
     if (!file) {
-        logger.log("[ol.control.LayerImport] missing file");
+        logger.warn("[ol.control.LayerImport] missing file");
         return;
     }
 
@@ -759,7 +759,7 @@ LayerImport.prototype._importStaticLayerFromLocalFile = function (layerName) {
     fReader.onerror = function (e) {
         // en cas d'erreur, on revient au panel initial et on cache la patience
         context._hideWaitingContainer();
-        logger.log("error fileReader : ", e);
+        logger.error("error fileReader : ", e);
     };
     /** on readAsText progress */
     fReader.onprogress = function () {
@@ -996,7 +996,7 @@ LayerImport.prototype._addFeaturesFromImportStaticLayerUrl = function (url, laye
  */
 LayerImport.prototype._importServiceLayers = function () {
     if (this._currentImportType === "WFS") {
-        logger.log("[ol.control.LayerImport] WFS layer import is not implemented yet");
+        logger.warn("[ol.control.LayerImport] WFS layer import is not implemented yet");
         return;
     }
 
@@ -1006,7 +1006,7 @@ LayerImport.prototype._importServiceLayers = function () {
     // 1. récupération de l'url renseignée
     var url = this._getCapRequestUrl = this._serviceUrlImportInput.value;
     if (!url) {
-        logger.log("[ol.control.LayerImport] url parameter is mandatory");
+        logger.error("[ol.control.LayerImport] url parameter is mandatory");
         return;
     }
     logger.log("url : ", url);
@@ -1028,7 +1028,7 @@ LayerImport.prototype._importServiceLayers = function () {
 
     // 2. récupération proxy
     if (!this.options.webServicesOptions || (!this.options.webServicesOptions.proxyUrl && !this.options.webServicesOptions.noProxyDomains)) {
-        logger.log("[ol.control.LayerImport] options.webServicesOptions.proxyUrl parameter is mandatory to request web service layers (getcapabilities request)");
+        logger.error("[ol.control.LayerImport] options.webServicesOptions.proxyUrl parameter is mandatory to request web service layers (getcapabilities request)");
         return;
     };
     var proxyUrl = this.options.webServicesOptions.proxyUrl;
@@ -1067,7 +1067,7 @@ LayerImport.prototype._importServiceLayers = function () {
         onFailure : function (error) {
             // en cas d'erreur, on revient au panel initial et on cache la patience
             context._hideWaitingContainer();
-            logger.log("[ol.control.LayerImport] getCapabilities request failed : ", error);
+            logger.error("[ol.control.LayerImport] getCapabilities request failed : ", error);
         }
     });
 };
@@ -1143,12 +1143,12 @@ LayerImport.prototype._displayGetCapResponseLayers = function (xmlResponse) {
                             // on ajoute chaque couche de la réponse dans la liste des couches accessibles
                             layerDescription = layers[j].Title;
                             if (this._getCapResultsListContainer) {
-                                this._getCapResultsListContainer.appendChild(this._createImportGetCapResultElement(layerDescription, j));
+                                this._addImportGetCapResultLayer(layerDescription, j, this._getCapResultsListContainer);
                             }
                         } else {
                             // si la projection de la couche n'est pas connue par ol.proj,
                             // on n'affiche pas la couche dans le panel des résultats
-                            logger.log("[ol.control.LayerImport] wmts layer cannot be added to map : unknown projection", layers[j]);
+                            logger.warn("[ol.control.LayerImport] wmts layer cannot be added to map : unknown projection", layers[j]);
                             continue;
                         }
                     }
@@ -1168,7 +1168,7 @@ LayerImport.prototype._displayGetCapResponseLayers = function (xmlResponse) {
  */
 LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, parentLayersInfos) {
     if (!layerObj) {
-        logger.log("[ol.control.LayerImport] _displayGetCapResponseWMSLayer : getCapabilities layer object not found");
+        logger.warn("[ol.control.LayerImport] _displayGetCapResponseWMSLayer : getCapabilities layer object not found");
     } else {
         logger.log("[ol.control.LayerImport] _displayGetCapResponseWMSLayer - layerObj : ", layerObj);
     }
@@ -1230,19 +1230,34 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
             }
         }
         // on affiche l'arborescence dans le titre de la couche (sauf si on est au premier niveau ?)
-        if (!parentLayersInfos._isRootLayer && parentLayersInfos.Title) {
-            layerObj.Title = parentLayersInfos.Title + " > " + layerObj.Title;
-        }
+        // if (!parentLayersInfos._isRootLayer && parentLayersInfos.Title) {
+        //     layerObj.Title = parentLayersInfos.Title + " > " + layerObj.Title;
+        // }
     } else {
         // si on n'a pas d'infos de couche parent, on est à la racine du Capability, on le note
         layerObj._isRootLayer = true;
+        layerObj._container = this._getCapResultsListContainer;
     }
 
     // 2. si on a d'autres couches <Layer> imbriquées, on descend d'un niveau, sinon on affiche la couche dans la liste des résultats
     if (layerObj.Layer) {
         if (Array.isArray(layerObj.Layer)) {
+            var _container = (layerObj) ? layerObj._container : parentLayersInfos._container;
+            var _title = (layerObj) ? layerObj.Title : parentLayersInfos.Title;
+            layerObj._container = this._addImportGetCapResultListRubrique(_title, _container).lastChild;
             for (var j = 0; j < layerObj.Layer.length; j++) {
                 // on recommence pour chaque sous couche, avec les infos éventuellement héritées
+                var bRubriqueExist = false;
+                var lstRubrique = layerObj._container.getElementsByClassName("GPimportGetCapRubriqueTitle");
+                for (var ii = 0; ii < lstRubrique.length; ii++) {
+                    if (lstRubrique[ii].title === layerObj.Title) {
+                        bRubriqueExist = true;
+                        layerObj.Layer[j]._container = lstRubrique[ii].parentElement;
+                    }
+                }
+                if (!bRubriqueExist) {
+                    layerObj.Layer[j]._container = this._addImportGetCapResultRubrique(layerObj.Title, layerObj._container);
+                }
                 this._displayGetCapResponseWMSLayer(layerObj.Layer[j], layerObj);
             }
         }
@@ -1257,15 +1272,19 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
         if (!projection) {
             // si aucune projection n'est compatible avec celle de la carte ou connue par ol.proj,
             // on n'affiche pas la couche dans le panel des résultats
-            logger.log("[ol.control.LayerImport] wms layer cannot be added to map : unknown projection", layerObj);
+            logger.warn("[ol.control.LayerImport] wms layer cannot be added to map : unknown projection", layerObj);
         } else {
             // si on a une projection compatible : on la stocke et la couche sera éventuellement reprojetée à l'ajout
             layerObj._projection = projection;
             // on ajoute chaque couche de la réponse dans la liste des couches accessibles
             layerDescription = layerObj.Title;
-            if (this._getCapResultsListContainer) {
-                this._getCapResultsListContainer.appendChild(this._createImportGetCapResultElement(layerDescription, lastIndex));
+            // FIXME beurk !?
+            var _isGoodContainer = layerObj._container;
+            if (_isGoodContainer.localName === "ul") {
+                _isGoodContainer = _isGoodContainer.lastChild;
             }
+            this._addImportGetCapResultLayer(layerDescription, lastIndex, _isGoodContainer);
+
             // puis on stoke la couche dans la liste pour faire le lien avec le DOM
             this._getCapResponseWMSLayers[lastIndex] = layerObj;
         }
@@ -1317,11 +1336,11 @@ LayerImport.prototype._onGetCapResponseLayerClick = function (e) {
 LayerImport.prototype._addGetCapWMSLayer = function (layerInfo) {
     var map = this.getMap();
     if (!map) {
-        logger.log("[ol.control.LayerImport] _addGetCapWMSLayer error : map is not defined");
+        logger.warn("[ol.control.LayerImport] _addGetCapWMSLayer error : map is not defined");
         return;
     }
     if (!layerInfo) {
-        logger.log("[ol.control.LayerImport] _addGetCapWMSLayer error : layerInfo is not defined");
+        logger.warn("[ol.control.LayerImport] _addGetCapWMSLayer error : layerInfo is not defined");
         return;
     }
 
@@ -1349,7 +1368,7 @@ LayerImport.prototype._addGetCapWMSLayer = function (layerInfo) {
     if (layerInfo.Name) {
         wmsSourceOptions.params["LAYERS"] = layerInfo.Name;
     } else {
-        logger.log("[ol.control.LayerImport] unable to add wms layer : mandatory layer 'name' parameter cannot be found", layerInfo);
+        logger.warn("[ol.control.LayerImport] unable to add wms layer : mandatory layer 'name' parameter cannot be found", layerInfo);
         return;
     }
     wmsSourceOptions.params["SERVICE"] = "WMS";
@@ -1362,7 +1381,7 @@ LayerImport.prototype._addGetCapWMSLayer = function (layerInfo) {
     // ou soit connue par proj4js
     var projection = layerInfo._projection;
     if (!projection) {
-        logger.log("[ol.control.LayerImport] wms layer cannot be added to map : unknown projection");
+        logger.warn("[ol.control.LayerImport] wms layer cannot be added to map : unknown projection");
         return;
     } else if (projection !== mapProjCode) {
         // si la projection de la carte n'est pas disponible pour cette couche,
@@ -1445,7 +1464,7 @@ LayerImport.prototype._getWMSLayerProjection = function (layerInfo, mapProjCode)
     var projection;
 
     if (!layerInfo || typeof layerInfo !== "object") {
-        logger.log("missing layer information (from getCapabilities)");
+        logger.warn("missing layer information (from getCapabilities)");
         return;
     }
 
@@ -1515,7 +1534,7 @@ LayerImport.prototype._getWMSLayerMinMaxResolution = function (layerInfo, mapPro
  */
 LayerImport.prototype._getWMSLayerExtent = function (layerInfo, mapProjCode, layerTileOptions) {
     if (!layerInfo) {
-        logger.log("[ol.control.LayerImport] _getWMSLayerExtent error : layerInfo is not defined");
+        logger.warn("[ol.control.LayerImport] _getWMSLayerExtent error : layerInfo is not defined");
         return;
     }
 
@@ -1635,7 +1654,7 @@ LayerImport.prototype._getWMSLayerInfoForLayerSwitcher = function (layerInfo, le
  */
 LayerImport.prototype._addGetCapWMTSLayer = function (layerInfo) {
     if (!layerInfo || !layerInfo.Identifier) {
-        logger.log("[ol.control.LayerImport] layer information not found in getCapabilities response for layer ");
+        logger.warn("[ol.control.LayerImport] layer information not found in getCapabilities response for layer ");
         return;
     }
 
@@ -1695,7 +1714,7 @@ LayerImport.prototype._addGetCapWMTSLayer = function (layerInfo) {
         }
     }
     if (defaultStyle == null) {
-        logger.log("[ol.control.LayerImport] style information not found in getCapabilities response for layer " + layerInfo.Identifier);
+        logger.warn("[ol.control.LayerImport] style information not found in getCapabilities response for layer " + layerInfo.Identifier);
     }
     wmtsSourceOptions.style = defaultStyle;
 
@@ -1705,7 +1724,7 @@ LayerImport.prototype._addGetCapWMTSLayer = function (layerInfo) {
         format = layerInfo.Format[0];
     }
     if (format == null) {
-        logger.log("[ol.control.LayerImport] format information not found in getCapabilities response for layer " + layerInfo.Identifier);
+        logger.warn("[ol.control.LayerImport] format information not found in getCapabilities response for layer " + layerInfo.Identifier);
     }
     wmtsSourceOptions.format = format;
 
@@ -1735,7 +1754,7 @@ LayerImport.prototype._addGetCapWMTSLayer = function (layerInfo) {
     try {
         wmtsLayer = new ol.layer.Tile(layerTileOptions);
     } catch (e) {
-        logger.log("[ol.control.LayerImport] an error occured while trying to create ol.layer.Tile from getCapabilities information. error : ", e);
+        logger.warn("[ol.control.LayerImport] an error occured while trying to create ol.layer.Tile from getCapabilities information. error : ", e);
         return;
     }
     // on rajoute le champ gpResultLayerId permettant d'identifier une couche crée par le composant. (pour layerSwitcher par ex)
@@ -1775,12 +1794,12 @@ LayerImport.prototype._getWMTSLayerProjection = function (layerInfo, getCapRespo
     var projection;
 
     if (!layerInfo || typeof layerInfo !== "object") {
-        logger.log("missing layer information (from getCapabilities)");
+        logger.warn("missing layer information (from getCapabilities)");
         return;
     }
 
     if (!getCapResponseWMTS || typeof getCapResponseWMTS !== "object") {
-        logger.log("missing getCapabilities response");
+        logger.warn("missing getCapabilities response");
         return;
     }
 
@@ -1902,7 +1921,7 @@ LayerImport.prototype._getTMSParams = function (layerInfo) {
                 }
             }
         } else {
-            logger.log("[ol.control.LayerImport] TileMatrixSet data not found in getCapabilities response for layer " + layerInfo.Identifier);
+            logger.warn("[ol.control.LayerImport] TileMatrixSet data not found in getCapabilities response for layer " + layerInfo.Identifier);
         }
     } else {
         return;
@@ -1950,7 +1969,7 @@ LayerImport.prototype._getWMTSLayerExtent = function (layerInfo) {
 LayerImport.prototype._getMapProjectionCode = function () {
     var map = this.getMap();
     if (!map || !map.getView || !map.getView().getProjection) {
-        logger.log("unable to get layerimport's map");
+        logger.warn("unable to get layerimport's map");
         return;
     }
     var mapProjCode = map.getView().getProjection().getCode();

--- a/src/OpenLayers/Controls/LayerImport.js
+++ b/src/OpenLayers/Controls/LayerImport.js
@@ -1229,14 +1229,13 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
                 layerObj[key] = parentLayersInfos[key];
             }
         }
-        // on affiche l'arborescence dans le titre de la couche (sauf si on est au premier niveau ?)
-        // if (!parentLayersInfos._isRootLayer && parentLayersInfos.Title) {
-        //     layerObj.Title = parentLayersInfos.Title + " > " + layerObj.Title;
-        // }
     } else {
         // si on n'a pas d'infos de couche parent, on est à la racine du Capability, on le note
         layerObj._isRootLayer = true;
         layerObj._container = this._getCapResultsListContainer;
+        if (!layerObj.Title) {
+            layerObj.Title = "Liste des couches";
+        }
     }
 
     // 2. si on a d'autres couches <Layer> imbriquées, on descend d'un niveau, sinon on affiche la couche dans la liste des résultats

--- a/src/OpenLayers/Controls/LayerImport.js
+++ b/src/OpenLayers/Controls/LayerImport.js
@@ -1256,7 +1256,7 @@ LayerImport.prototype._displayGetCapResponseWMSLayer = function (layerObj, paren
                     }
                 }
                 if (!bRubriqueExist) {
-                    layerObj.Layer[j]._container = this._addImportGetCapResultRubrique(layerObj.Title, layerObj._container);
+                    layerObj.Layer[j]._container = this._addImportGetCapResultRubrique(layerObj.Title, layerObj._container).lastChild;
                 }
                 this._displayGetCapResponseWMSLayer(layerObj.Layer[j], layerObj);
             }


### PR DESCRIPTION
cf. issue #61 

L'import des couches WMS (ou WMTS), les couches est organisées en catégorie (ou arborescence). Il est possible de plier/déplier les catégories.

**TODO**
> - gestion des messages d'erreurs (à réaliser dans une autre PR)
> - customisation des puces des rubriques 

Exemples pour tester cette fonctionnalité : 
- http://localhost/samples/openlayers/LayerImport/pages-ol-layerimport-bundle-wms-proxy.html
- http://localhost/samples/openlayers/LayerImport/pages-ol-layerimport-bundle-wmts-proxy.html