### PR TITLE
Utilisation du https par défaut

### DIFF
--- a/src/Itowns/Controls/MousePosition.js
+++ b/src/Itowns/Controls/MousePosition.js
@@ -21,6 +21,7 @@ var logger = Logger.getLogger("MousePosition");
  * @alias itowns.control.MousePosition
  * @extends {itowns.control.Control}
  * @param {Object} options - options for function call.
+ * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)   
  * @param {Boolean} [options.collapsed = true] - Specify if MousePosition control should be collapsed at startup. Default is true.
  * @param {Array}   [options.systems] - list of projection systems, default are Geographical ("EPSG:4326"), Web Mercator ("EPSG:3857"), Lambert 93 ("EPSG:2154") and extended Lambert 2 ("EPSG:27572").
  *      Each array element (=system) is an object with following properties :
@@ -1079,6 +1080,10 @@ MousePosition.prototype.onRequestAltitude = function (coordinate, callback) {
     // in the case of the API key is not given as option of the service,
     // we use the key of the autoconf, or the key given in the control options
     options.apiKey = options.apiKey || this.options.apiKey;
+
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
 
     Gp.Services.getAltitude(options);
 };

--- a/src/Itowns/Layer/LayerWMS.js
+++ b/src/Itowns/Layer/LayerWMS.js
@@ -50,9 +50,10 @@ function LayerWMS (options) {
         var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
         // gestion de mixContent dans l'url du service...
+        // en mode browser, on requête en https
         var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
         var protocol = (ctx)
-            ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://")
+            ? "https://"
             : (options.ssl ? "https://" : "http://");
 
         this.type = "color";

--- a/src/Itowns/Layer/LayerWMS.js
+++ b/src/Itowns/Layer/LayerWMS.js
@@ -36,7 +36,7 @@ function LayerWMS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded
@@ -49,12 +49,9 @@ function LayerWMS (options) {
     if (layerId && Config.configuration.getLayerConf(layerId)) {
         var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
-        // gestion de mixContent dans l'url du service...
-        // en mode browser, on requête en https
-        var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-        var protocol = (ctx)
-            ? "https://"
-            : (options.ssl ? "https://" : "http://");
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        var protocol = options.ssl === false ? "http://" : "https://";
 
         this.type = "color";
         this.protocol = "wms";

--- a/src/Itowns/Layer/LayerWMTS.js
+++ b/src/Itowns/Layer/LayerWMTS.js
@@ -36,7 +36,7 @@ function LayerWMTS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded
@@ -49,12 +49,9 @@ function LayerWMTS (options) {
     if (layerId && Config.configuration.getLayerConf(layerId)) {
         var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
-        // gestion de mixContent dans l'url du service...
-        // en mode browser, on requête en https
-        var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-        var protocol = (ctx)
-            ? "https://"
-            : (options.ssl ? "https://" : "http://");
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        var protocol = options.ssl === false ? "http://" : "https://";
 
         this.type = "color";
         this.protocol = "wmts";

--- a/src/Itowns/Layer/LayerWMTS.js
+++ b/src/Itowns/Layer/LayerWMTS.js
@@ -50,9 +50,10 @@ function LayerWMTS (options) {
         var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
         // gestion de mixContent dans l'url du service...
+        // en mode browser, on requête en https
         var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
         var protocol = (ctx)
-            ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://")
+            ? "https://"
             : (options.ssl ? "https://" : "http://");
 
         this.type = "color";

--- a/src/Leaflet/Controls/ElevationPath.js
+++ b/src/Leaflet/Controls/ElevationPath.js
@@ -55,6 +55,7 @@ var ElevationPath = L.Control.extend(/** @lends L.geoportalControl.ElevationPath
      * @private
      * @param {Object} options - ElevationPath control options
      * @param {Sting}   [options.apiKey] - API key for services call (isocurve and autocomplete services), mandatory if autoconf service has not been charged in advance
+    * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
      * @param {Boolean} [options.active] - Specify if widget has to be actived to drawing (true) or not (false) on map loading. Default is false.
      * @param {Object} [options.elevationPathOptions = {}] - elevation service options. See {@link http://ignf.github.io/geoportal-access-lib/latest/jsdoc/module-Services.html#~getAltitude Gp.Services.getAltitude()} to know all elevation options
      * @param {Object} [options.displayProfileOptions = {}] - profile options.
@@ -653,6 +654,12 @@ var ElevationPath = L.Control.extend(/** @lends L.geoportalControl.ElevationPath
         // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
         L.Util.extend(options, {
             apiKey : options.apiKey || this.options.apiKey
+        });
+
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https) 
+        L.Util.extend(options, {
+            ssl : this.options.ssl
         });
 
         // le sampling est soit defini par l'utilisateur (opts),

--- a/src/Leaflet/Controls/Isocurve.js
+++ b/src/Leaflet/Controls/Isocurve.js
@@ -51,6 +51,7 @@ var Isocurve = L.Control.extend(/** @lends L.geoportalControl.Isocurve.prototype
      * @private
      * @param {Object} options - Isocurve control options
      * @param {Sting}   [options.apiKey] - API key for services call (isocurve and autocomplete services), mandatory if autoconf service has not been charged in advance
+     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
      * @param {Boolean} [options.collapsed] - Specify if widget has to be collapsed (true) or not (false) on map loading. Default is true.
      * @param {Object}  [options.exclusions] - list of exclusions with status (true = checked), by default : ["toll":false, "tunnel":false, "bridge":false].
      * @param {Array}   [options.graphs] - list of graph resources to be used for isocurve calculation, by default : ["Voiture", "Pieton"]. The first element is selected.
@@ -902,6 +903,10 @@ var Isocurve = L.Control.extend(/** @lends L.geoportalControl.Isocurve.prototype
         // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
         var key = this._resources["Isochrone"]["key"];
         options.apiKey = this.options.isocurveOptions.apiKey || this.options.apiKey || key;
+        
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https)
+        options.ssl = this.options.ssl;
 
         logger.log(options);
 

--- a/src/Leaflet/Controls/MousePosition.js
+++ b/src/Leaflet/Controls/MousePosition.js
@@ -56,6 +56,7 @@ var MousePosition = L.Control.extend(/** @lends L.geoportalControl.MousePosition
      * @extends {L.Control}
      * @param {Object} options - options for function call.
      * @param {Sting}   [options.apiKey] - API key, mandatory if autoconf service has not been charged in advance
+     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)   
      * @param {String}  [options.position] - position of component into the map, 'bottomleft' by default
      * @param {Boolean} [options.collapsed] - collapse mode, false by default
      * @param {Array}   [options.systems] - list of projection systems, GEOGRAPHIC, MERCATOR, LAMB93 and LAMB2E by default
@@ -1027,6 +1028,13 @@ var MousePosition = L.Control.extend(/** @lends L.geoportalControl.MousePosition
         // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
         L.Util.extend(options, {
             apiKey : options.apiKey || this.options.apiKey
+        });
+
+
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https) 
+        L.Util.extend(options, {
+            ssl : this.options.ssl
         });
 
         logger.log(options);

--- a/src/Leaflet/Controls/ReverseGeocoding.js
+++ b/src/Leaflet/Controls/ReverseGeocoding.js
@@ -42,6 +42,7 @@ var ReverseGeocoding = L.Control.extend(/** @lends L.geoportalControl.ReverseGeo
      * @constructor ReverseGeocode
      * @param {Object} options - ReverseGeocoding control options
      * @param {String}  [options.apiKey] - API key for services call (reverse geocode service), mandatory if autoconf service has not been charged in advance
+     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)   
      * @param {String}  [options.position] - position of component into the map, 'topleft' by default
      * @param {Boolean} [options.collapsed] - Specify if widget has to be collapsed (true) or not (false) on map loading. Default is true.
      * @param {Array}  [options.resources] - resources for geocoding, by default : ["StreetAddress", "PositionOfInterest"]
@@ -712,6 +713,7 @@ var ReverseGeocoding = L.Control.extend(/** @lends L.geoportalControl.ReverseGeo
         // options par defaut
         L.Util.extend(options, {
             apiKey : this.options.apiKey,
+            ssl : this.options.ssl,
             srs : "EPSG:4326",
             returnFreeForm : false,
             // maximumResponses : 25, // on peut la surcharger !

--- a/src/Leaflet/Controls/Route.js
+++ b/src/Leaflet/Controls/Route.js
@@ -48,6 +48,7 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
      * @private
      * @param {Object} options - options for function call.
      * @param {Sting}   [options.apiKey] - API key, mandatory if autoconf service has not been charged in advance
+     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
      * @param {String}  [options.position] - position of component into the map, 'topleft' by default
      * @param {Boolean} [options.collapsed] - collapse mode, false by default
      * @param {Object}  [options.exclusions] - list of exclusions with status
@@ -988,6 +989,12 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
         // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
         L.Util.extend(options, {
             apiKey : this.options.routeOptions.apiKey || this.options.apiKey || key
+        });
+
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https) 
+        L.Util.extend(options, {
+            ssl : this.options.ssl
         });
 
         logger.log(options);

--- a/src/Leaflet/Controls/SearchEngine.js
+++ b/src/Leaflet/Controls/SearchEngine.js
@@ -62,6 +62,7 @@ var SearchEngine = L.Control.extend(/** @lends L.geoportalControl.SearchEngine.p
      * @extends {L.Control}
      * @param {Object} options - control options
      * @param {String} [options.apiKey] - API key, mandatory if autoconf service has not been charged in advance
+     * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
      * @param {Boolean} [options.collapsed] - collapse mode, false by default
      * @param {String} [options.position] - position of component into the map, 'topleft' by default
      * @param {Boolean} [options.displayInfo] - get informations on popup marker
@@ -785,6 +786,12 @@ var SearchEngine = L.Control.extend(/** @lends L.geoportalControl.SearchEngine.p
             apiKey : options.apiKey || this.options.apiKey || key
         });
 
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https) 
+        L.Util.extend(options, {
+            ssl : this.options.ssl
+        });
+
         logger.log(options);
 
         Gp.Services.autoComplete(options);
@@ -887,6 +894,12 @@ var SearchEngine = L.Control.extend(/** @lends L.geoportalControl.SearchEngine.p
         // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
         L.Util.extend(options, {
             apiKey : options.apiKey || this.options.apiKey || key
+        });
+
+        // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+        // true par défaut (https) 
+        L.Util.extend(options, {
+            ssl : this.options.ssl
         });
 
         logger.log(options);

--- a/src/Leaflet/Layers/Layers.js
+++ b/src/Leaflet/Layers/Layers.js
@@ -45,7 +45,7 @@ var Layers = {
 
         // par defaut
         if (typeof this.options.ssl === "undefined") {
-            this.options.ssl = false;
+            this.options.ssl = true;
         }
     },
 
@@ -53,12 +53,9 @@ var Layers = {
      * get runtime context
      */
     _initContext : function () {
-        var _context = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-        // en mode browser, on requête en https
-        var _protocol = (_context)
-            ? "https://"
-            : (this.options.ssl ? "https://" : "http://");
-        this.protocol = _protocol;
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        this.protocol = this.options.ssl === false ? "http://" : "https://";
     },
 
     /**

--- a/src/Leaflet/Layers/Layers.js
+++ b/src/Leaflet/Layers/Layers.js
@@ -54,8 +54,9 @@ var Layers = {
      */
     _initContext : function () {
         var _context = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
+        // en mode browser, on requête en https
         var _protocol = (_context)
-            ? (_context.location && _context.location.protocol && _context.location.protocol.indexOf("https:") === 0 ? "https://" : "http://")
+            ? "https://"
             : (this.options.ssl ? "https://" : "http://");
         this.protocol = _protocol;
     },
@@ -143,7 +144,7 @@ var Layers = {
         var serviceUrl = null;
         if (this.params.key || this.options.apiKey) {
             // url de l'autoconf ou le service par defaut
-            serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/r/wms", {
+            serviceUrl = this.params.url || L.Util.template("https://wxs.ign.fr/{key}/geoportail/r/wms", {
                 key : this.params.key || this.options.apiKey
             });
         } else {
@@ -241,7 +242,7 @@ var Layers = {
         // url du service (par defaut)
         var serviceUrl = null;
         if (this.params.key || this.options.apiKey) {
-            serviceUrl = this.params.url || L.Util.template("http://wxs.ign.fr/{key}/geoportail/wmts", {
+            serviceUrl = this.params.url || L.Util.template("https://wxs.ign.fr/{key}/geoportail/wmts", {
                 key : this.params.key || this.options.apiKey
             });
         } else {

--- a/src/OpenLayers/Controls/ElevationPath.js
+++ b/src/OpenLayers/Controls/ElevationPath.js
@@ -24,6 +24,7 @@ var logger = Logger.getLogger("elevationpath");
  * @extends ol.control.Control
  * @param {Object} options - options for function call.
  * @param {Boolean} [options.active = false] - specify if control should be actived at startup. Default is false.
+ * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
  * @param {Object} [options.layerDescription = {}] - Layer informations to be displayed in LayerSwitcher widget (only if a LayerSwitcher is also added to the map)
  * @param {String} [options.layerDescription.title = "Profil altimétrique"] - Layer title to be displayed in LayerSwitcher
  * @param {String} [options.layerDescription.description = "Mon profil altimétrique"] - Layer description to be displayed in LayerSwitcher
@@ -1085,6 +1086,12 @@ ElevationPath.prototype._requestService = function () {
     // au cas où ...
     Utils.mergeParams(options, {
         apiKey : this.options.apiKey
+    });
+
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    Utils.mergeParams(options, {
+        ssl : this.options.ssl
     });
 
     // les callbacks

--- a/src/OpenLayers/Controls/Isocurve.js
+++ b/src/OpenLayers/Controls/Isocurve.js
@@ -1001,6 +1001,10 @@ Isocurve.prototype._requestIsoCurve = function (options) {
     var key = this._resources["Isocurve"]["key"];
     options.apiKey = this.options.isocurveOptions.apiKey || this.options.apiKey || key;
 
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
+
     logger.log(options);
 
     // on efface une éventuelle précédente couche

--- a/src/OpenLayers/Controls/LocationSelector.js
+++ b/src/OpenLayers/Controls/LocationSelector.js
@@ -773,6 +773,10 @@ LocationSelector.prototype._requestAutoComplete = function (settings) {
     // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
     options.apiKey = options.apiKey || this.options.apiKey;
 
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
+
     logger.log(options);
 
     Gp.Services.autoComplete(options);

--- a/src/OpenLayers/Controls/MousePosition.js
+++ b/src/OpenLayers/Controls/MousePosition.js
@@ -20,6 +20,7 @@ var logger = Logger.getLogger("GeoportalMousePosition");
  * @extends {ol.control.Control}
  * @param {Object} options - options for function call.
  * @param {Sting}   [options.apiKey] - API key, mandatory if autoconf service has not been charged in advance
+ * @param {Boolean} [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
  * @param {Boolean} [options.collapsed = true] - Specify if MousePosition control should be collapsed at startup. Default is true.
  * @param {Array}   [options.systems] - list of projection systems, default are Geographical ("EPSG:4326"), Web Mercator ("EPSG:3857"), Lambert 93 ("EPSG:2154") and extended Lambert 2 ("EPSG:27572").
  *      Each array element (=system) is an object with following properties :
@@ -1233,10 +1234,15 @@ MousePosition.prototype.onRequestAltitude = function (coordinate, callback) {
     // cas où la clef API n'est pas renseignée dans les options du service,
     // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
     var _apiKey = options.apiKey || this.options.apiKey;
+    
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    var _ssl = this.options.ssl;
 
     Gp.Services.getAltitude({
         apiKey : _apiKey,
         protocol : _protocol,
+        ssl : _ssl,
         timeOut : _timeout,
         scope : _scope,
         rawResponse : _rawResponse,

--- a/src/OpenLayers/Controls/ReverseGeocode.js
+++ b/src/OpenLayers/Controls/ReverseGeocode.js
@@ -20,6 +20,7 @@ var logger = Logger.getLogger("reversegeocoding");
  * @extends {ol.control.Control}
  * @param {Object} options - ReverseGeocode control options
  * @param {String}   [options.apiKey] - API key for services call (reverse geocode service), mandatory if autoconf service has not been charged in advance
+ * @param {String}   [options.ssl = true] - use of ssl or not (default true, service requested using https protocol) 
  * @param {Boolean} [options.collapsed = true] - Specify if widget has to be collapsed (true) or not (false) on map loading. Default is true.
  * @param {Object}   [options.resources =  ["StreetAddress", "PositionOfInterest", "CadastralParcel"]] - resources for geocoding, by default : ["StreetAddress", "PositionOfInterest", "CadastralParcel"]. Possible values are : "StreetAddress", "PositionOfInterest", "CadastralParcel", "Administratif". Resources will be displayed in the same order in widget list.
  * @param {Object}   [options.delimitations = ["Point", "Circle", "Extent"]] - delimitations for reverse geocoding, by default : ["Point", "Circle", "Extent"]. Possible values are : "Point", "Circle", "Extent". Delimitations will be displayed in the same order in widget list.
@@ -1005,6 +1006,7 @@ ReverseGeocode.prototype._getReverseGeocodingRequestOptions = function () {
     var context = this;
     var requestOptions = {
         apiKey : reverseGeocodeOptions.apiKey || this.options.apiKey,
+        ssl : this.options.ssl,
         position : this._requestPosition,
         filterOptions : {
             type : [this._currentGeocodingType]

--- a/src/OpenLayers/Controls/Route.js
+++ b/src/OpenLayers/Controls/Route.js
@@ -21,6 +21,7 @@ var logger = Logger.getLogger("route");
  * @extends {ol.control.Control}
  * @param {Object} options - route control options
  * @param {String}   [options.apiKey] - API key for services call (route and autocomplete services), mandatory if autoconf service has not been charged in advance
+ * @param {Boolean}   [options.ssl = true] - use of ssl or not (default true, service requested using https protocol)  
  * @param {Boolean} [options.collapsed = true] - Specify if widget has to be collapsed (true) or not (false) on map loading. Default is true.
  * @param {Object}  [options.exclusions = {toll : false, tunnel : false, bridge : false}] - list of exclusions with status (true = checked). By default : no exclusions checked.
  * @param {Array}   [options.graphs = ["Voiture", "Pieton"]] - list of resources, by default : ["Voiture", "Pieton"]. The first element is selected.
@@ -1220,6 +1221,10 @@ Route.prototype._requestRouting = function (options) {
     // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
     options.apiKey = this.options.routeOptions.apiKey || this.options.apiKey || key;
 
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
+    
     logger.log(options);
 
     // mise en place de la patience

--- a/src/OpenLayers/Controls/SearchEngine.js
+++ b/src/OpenLayers/Controls/SearchEngine.js
@@ -19,6 +19,7 @@ var logger = Logger.getLogger("searchengine");
  * @alias ol.control.SearchEngine
  * @param {Object}  options - control options
  * @param {String}   [options.apiKey] - API key, mandatory if autoconf service has not been charged in advance
+ * @param {String}   [options.ssl = true] - use of ssl or not (default true, service requested using https protocol) 
  * @param {Boolean} [options.collapsed = true] - collapse mode, true by default
  * @param {Object}   [options.resources] - resources to be used by geocode and autocompletion services :
  * @param {Array}   [options.resources.geocode] - resources geocoding, by default : ["PositionOfInterest", "StreetAddress"]
@@ -735,6 +736,10 @@ SearchEngine.prototype._requestAutoComplete = function (settings) {
     // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
     options.apiKey = options.apiKey || this.options.apiKey;
 
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
+
     logger.log(options);
 
     Gp.Services.autoComplete(options);
@@ -814,6 +819,10 @@ SearchEngine.prototype._requestGeocoding = function (settings) {
     // cas où la clef API n'est pas renseignée dans les options du service,
     // on utilise celle de l'autoconf ou celle renseignée au niveau du controle
     options.apiKey = options.apiKey || this.options.apiKey;
+
+    // si l'utilisateur a spécifié le paramètre ssl au niveau du control, on s'en sert
+    // true par défaut (https) 
+    options.ssl = this.options.ssl;
 
     logger.log(options);
 
@@ -1254,6 +1263,7 @@ SearchEngine.prototype._getGeocodeCoordinatesFromFullText = function (suggestedL
     var context = this;
     Gp.Services.geocode({
         apiKey : this.options.apiKey,
+        ssl : this.options.ssl,
         location : suggestedLocation.fullText,
         filterOptions : {
             type : suggestedLocation.type

--- a/src/OpenLayers/Layers/LayerWMS.js
+++ b/src/OpenLayers/Layers/LayerWMS.js
@@ -36,7 +36,7 @@ function LayerWMS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded

--- a/src/OpenLayers/Layers/LayerWMTS.js
+++ b/src/OpenLayers/Layers/LayerWMTS.js
@@ -37,7 +37,7 @@ function LayerWMTS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded

--- a/src/OpenLayers/Layers/SourceWMS.js
+++ b/src/OpenLayers/Layers/SourceWMS.js
@@ -53,9 +53,10 @@ function SourceWMS (options) {
         var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
         // gestion de mixContent dans l'url du service...
+        // en mode browser, on requête en https
         var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
         var protocol = (ctx)
-            ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://")
+            ? "https://"
             : (options.ssl ? "https://" : "http://");
 
         var wmsSourceOptions = {

--- a/src/OpenLayers/Layers/SourceWMS.js
+++ b/src/OpenLayers/Layers/SourceWMS.js
@@ -39,7 +39,7 @@ function SourceWMS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded
@@ -52,12 +52,9 @@ function SourceWMS (options) {
     if (layerId && Config.configuration.getLayerConf(layerId)) {
         var wmsParams = Config.getLayerParams(options.layer, "WMS", options.apiKey);
 
-        // gestion de mixContent dans l'url du service...
-        // en mode browser, on requête en https
-        var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-        var protocol = (ctx)
-            ? "https://"
-            : (options.ssl ? "https://" : "http://");
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        var protocol = options.ssl === false ? "http://" : "https://";
 
         var wmsSourceOptions = {
             // tracker extension openlayers

--- a/src/OpenLayers/Layers/SourceWMTS.js
+++ b/src/OpenLayers/Layers/SourceWMTS.js
@@ -41,7 +41,7 @@ function SourceWMTS (options) {
 
     // par defaut
     if (typeof options.ssl === "undefined") {
-        options.ssl = false;
+        options.ssl = true;
     }
 
     // Check if configuration is loaded
@@ -54,12 +54,9 @@ function SourceWMTS (options) {
     if (layerId && Config.configuration.getLayerConf(layerId)) {
         var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
-        // gestion de mixContent dans l'url du service...
-        // en mode browser, on requête en https
-        var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
-        var protocol = (ctx)
-            ? "https://"
-            : (options.ssl ? "https://" : "http://");
+        // si ssl = false on fait du http
+        // par défaut, ssl = true, on fait du https
+        var protocol = options.ssl === false ? "http://" : "https://";
 
         // save originators (to be updated by Originators control)
         this._originators = wmtsParams.originators;

--- a/src/OpenLayers/Layers/SourceWMTS.js
+++ b/src/OpenLayers/Layers/SourceWMTS.js
@@ -55,9 +55,10 @@ function SourceWMTS (options) {
         var wmtsParams = Config.getLayerParams(options.layer, "WMTS", options.apiKey);
 
         // gestion de mixContent dans l'url du service...
+        // en mode browser, on requête en https
         var ctx = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : null;
         var protocol = (ctx)
-            ? (ctx.location && ctx.location.protocol && ctx.location.protocol.indexOf("https:") === 0 ? "https://" : "http://")
+            ? "https://"
             : (options.ssl ? "https://" : "http://");
 
         // save originators (to be updated by Originators control)


### PR DESCRIPTION
Utilisation du https par défaut sur les controles et l'ajout de couche Géoportail.

Paramétrable avec l'option ssl : false lors de l'ajout de couche ou control pour forcer du http.
La documentation a été mise à jour en ce sens.