### PR TITLE
issue #234 : gestion des icônes pour des écrans Retina (Extensions Leaflet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,20 @@
-Extension Géoportail, version 2.0.0
+Extension Géoportail, version 2.1.1
 
-**10/04/2018 : 2.0.0** Release Extension Géoportail
+**10/04/2018 : 2.1.1** Release Extension Géoportail
 
 ## SUMMARY
 
-Migration du projet sous [Webpack](http://webpack.github.io/) ainsi que les sources en [ES6 modules](http://exploringjs.com/es6/ch_modules.html).
+Gestion des icônes pour des écrans de type *Retina* sur les extensions Leaflet.
 
-### leaflet-2.0.1
+### leaflet-2.0.4
+
+[#234](https://github.com/IGNF/geoportal-extensions/issues/234) - Pas de marqueur sur résultat barre de recherche (SearchEngine) Leaflet
+
+### openlayers-2.1.2
 
 ...
 
-### openlayers-2.0.0
-
-**BREAKING CHANGES**
-
-Le nom du bundle a été modifié :
-> GpPluginOl3 vers GpPluginOpenLayers
-
-Pour l'url de la jsdoc courante, on l'a modifié aussi :
-> http://ignf.github.io/geoportal-extensions/current/jsdoc/ol3 vers http://ignf.github.io/geoportal-extensions/current/jsdoc/openlayers
-
-Idem pour l'url vers les binaires :
-> http://ignf.github.io/geoportal-extensions/current/dist/ol3/GpPluginOl3.js vers http://ignf.github.io/geoportal-extensions/current/dist/openlayers/GpPluginOpenLayers.js
-
-### itowns-2.0.0
+### itowns-2.1.2
 
 ...
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "itownsExtName": "French Geoportal Extension for Itowns",
   "olItownsExtName": "French Geoportal Extension for OpenLayers & Itowns",
   "version": "2.1.1",
-  "leafletExtVersion": "2.0.3",
+  "leafletExtVersion": "2.0.4",
   "olExtVersion": "2.1.2",
   "itownsExtVersion": "2.1.2",
   "olItownsExtVersion": "2.1.2",

--- a/samples-src/pages/leaflet/Default/pages-leaflet-amd.html
+++ b/samples-src/pages/leaflet/Default/pages-leaflet-amd.html
@@ -37,7 +37,7 @@
                 timeOut : 20000,
                 onSuccess : function () {
 
-                  var wms = L.geoportalLayer.WMS({
+                  var wmts = L.geoportalLayer.WMTS({
                     layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                   });
 
@@ -46,7 +46,7 @@
                     center : L.latLng(48, 2)
                   });
 
-                  wms.addTo(map);
+                  wmts.addTo(map);
 
                   var switcher = new L.geoportalControl.LayerSwitcher();
                   map.addControl(switcher);

--- a/samples-src/pages/leaflet/Default/pages-leaflet-bundle.html
+++ b/samples-src/pages/leaflet/Default/pages-leaflet-bundle.html
@@ -27,7 +27,7 @@
       document.getElementById("map").style.backgroundImage = "none";
 
       // Création de la map
-      var layer = L.geoportalLayer.WMS({
+      var layer = L.geoportalLayer.WMTS({
         layer : "ORTHOIMAGERY.ORTHOPHOTOS"
       });
 

--- a/samples-src/pages/leaflet/Default/pages-leaflet-es6.html
+++ b/samples-src/pages/leaflet/Default/pages-leaflet-es6.html
@@ -32,7 +32,7 @@
           document.getElementById("map").style.backgroundImage = "none";
 
           // Création de la map
-          var layer = L.geoportalLayer.WMS({
+          var layer = L.geoportalLayer.WMTS({
             layer : "ORTHOIMAGERY.ORTHOPHOTOS"
           });
 

--- a/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-amchart.html
+++ b/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-amchart.html
@@ -56,7 +56,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -65,7 +65,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.ElevationPath({
                   active : true,

--- a/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-d3.html
+++ b/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-d3.html
@@ -56,7 +56,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -65,7 +65,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.ElevationPath({
                   active : true,

--- a/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-default.html
+++ b/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-default.html
@@ -36,7 +36,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -45,7 +45,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.ElevationPath();
 

--- a/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-raw.html
+++ b/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-amd-raw.html
@@ -45,7 +45,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -54,7 +54,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.ElevationPath({
                   active : true,

--- a/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-bundle-default.html
+++ b/samples-src/pages/leaflet/ElevationPath/pages-leaflet-elevationpath-bundle-default.html
@@ -23,7 +23,7 @@
         <script type="text/javascript">
           window.onload = function () {
 
-            var layer = L.geoportalLayer.WMS({
+            var layer = L.geoportalLayer.WMTS({
               layer : "ORTHOIMAGERY.ORTHOPHOTOS"
             });
 

--- a/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-amd-default.html
+++ b/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-amd-default.html
@@ -36,7 +36,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -45,7 +45,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var mouse = new L.geoportalControl.MousePosition();
 

--- a/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-amd-opts-editcoordinates.html
+++ b/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-amd-opts-editcoordinates.html
@@ -43,7 +43,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -52,7 +52,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var mouse = new L.geoportalControl.MousePosition({
                     editCoordinates : true

--- a/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-bundle-default.html
+++ b/samples-src/pages/leaflet/MousePosition/pages-leaflet-mouseposition-bundle-default.html
@@ -23,7 +23,7 @@
         <script type="text/javascript">
           window.onload = function () {
 
-            var layer = L.geoportalLayer.WMS({
+            var layer = L.geoportalLayer.WMTS({
               layer : "ORTHOIMAGERY.ORTHOPHOTOS"
             });
 

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-default.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-default.html
@@ -36,7 +36,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -45,7 +45,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.SearchEngine();
 

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-option-markerdisplay.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-option-markerdisplay.html
@@ -49,7 +49,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -58,7 +58,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.SearchEngine({
                   placeholder : "Recherche...",

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-services.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-services.html
@@ -58,7 +58,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -67,7 +67,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.SearchEngine({
                   collapsed : false,

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-trigger.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options-trigger.html
@@ -45,11 +45,11 @@
             Gp.Services.getConfig({
               serverUrl : "{{ resources }}/AutoConf.js",
               callbackSuffix : "",
-              // apiKey : "jhyvi0fgmnuxvfv0zjzorvdn",
+              // apiKey : "jhyvi0fgmnuxvfv0jzorvdn",
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -58,7 +58,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.SearchEngine({
                   geocodeOptions : {},

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-amd-options.html
@@ -52,7 +52,7 @@
               timeOut : 20000,
               onSuccess : function () {
 
-                var wms = L.geoportalLayer.WMS({
+                var wmts = L.geoportalLayer.WMTS({
                   layer : "ORTHOIMAGERY.ORTHOPHOTOS",
                 });
 
@@ -61,7 +61,7 @@
                   center : L.latLng(48, 2)
                 });
 
-                wms.addTo(map);
+                wmts.addTo(map);
 
                 var search = new L.geoportalControl.SearchEngine({
                   collapsed : false,

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-bundle-default.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-bundle-default.html
@@ -23,7 +23,7 @@
         <script type="text/javascript">
           window.onload = function () {
 
-            var layer = L.geoportalLayer.WMS({
+            var layer = L.geoportalLayer.WMTS({
               layer : "ORTHOIMAGERY.ORTHOPHOTOS"
             });
 

--- a/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-bundle-options.html
+++ b/samples-src/pages/leaflet/SearchEngine/pages-leaflet-searchengine-bundle-options.html
@@ -39,7 +39,7 @@
         <script type="text/javascript">
           window.onload = function () {
 
-            var layer = L.geoportalLayer.WMS({
+            var layer = L.geoportalLayer.WMTS({
               layer : "ORTHOIMAGERY.ORTHOPHOTOS"
             });
 

--- a/src/Leaflet/Controls/Utils/IconDefault.js
+++ b/src/Leaflet/Controls/Utils/IconDefault.js
@@ -6,7 +6,20 @@ var logger = Logger.getLogger("icondefault");
 /**  cf. http://leafletjs.com/reference.html#icon */
 var IconDefault = L.Icon.Default.extend(/** @lends IconDefault.prototype */ {
 
+    /**
+    * Liste des icones
+    *   TODO : image retina à convertir en x2...
+    */
     images : {
+        retina : {
+            shadow : "data:image/png;base64,...",
+            color : {
+                blue : "data:image/png;base64,...",
+                orange : "data:image/png;base64,...",
+                red : "data:image/png;base64,...",
+                green : "data:image/png;base64,..."
+            }
+        },
         shadow : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAApCAYAAACoYAD2AAAC5ElEQVRYw+2YW4/TMBCF45S0S1luXZCABy5CgLQgwf//S4BYBLTdJLax0fFqmB07nnQfEGqkIydpVH85M+NLjPe++dcPc4Q8Qh4hj5D/AaQJx6H/4TMwB0PeBNwU7EGQAmAtsNfAzoZkgIa0ZgLMa4Aj6CxIAsjhjOCoL5z7Glg1JAOkaicgvQBXuncwJAWjksLtBTWZe04CnYRktUGdilALppZBOgHGZcBzL6OClABvMSVIzyBjazOgrvACf1ydC5mguqAVg6RhdkSWQFj2uxfaq/BrIZOLEWgZdALIDvcMcZLD8ZbLC9de4yR1sYMi4G20S4Q/PWeJYxTOZn5zJXANZHIxAd4JWhPIloTJZhzMQduM89WQ3MUVAE/RnhAXpTycqys3NZALOBbB7kFrgLesQl2h45Fcj8L1tTSohUwuxhy8H/Qg6K7gIs+3kkaigQCOcyEXCHN07wyQazhrmIulvKMQAwMcmLNqyCVyMAI+BuxSMeTk3OPikLY2J1uE+VHQk6ANrhds+tNARqBeaGc72cK550FP4WhXmFmcMGhTwAR1ifOe3EvPqIegFmF+C8gVy0OfAaWQPMR7gF1OQKqGoBjq90HPMP01BUjPOqGFksC4emE48tWQAH0YmvOgF3DST6xieJgHAWxPAHMuNhrImIdvoNOKNWIOcE+UXE0pYAnkX6uhWsgVXDxHdTfCmrEEmMB2zMFimLVOtiiajxiGWrbU52EeCdyOwPEQD8LqyPH9Ti2kgYMf4OhSKB7qYILbBv3CuVTJ11Y80oaseiMWOONc/Y7kJYe0xL2f0BaiFTxknHO5HaMGMublKwxFGzYdWsBF174H/QDknhTHmHHN39iWFnkZx8lPyM8WHfYELmlLKtgWNmFNzQcC1b47gJ4hL19i7o65dhH0Negbca8vONZoP7doIeOC9zXm8RjuL0Gf4d4OYaU5ljo3GYiqzrWQHfJxA6ALhDpVKv9qYeZA8eM3EhfPSCmpuD0AAAAASUVORK5CYII=",
         color : {
             blue : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAGmklEQVRYw7VXeUyTZxjvNnfELFuyIzOabermMZEeQC/OclkO49CpOHXOLJl/CAURuYbQi3KLgEhbrhZ1aDwmaoGqKII6odATmH/scDFbdC7LvFqOCc+e95s2VG50X/LLm/f4/Z7neY/ne18aANCmAr5E/xZf1uDOkTcGcWR6hl9247tT5U7Y6SNvWsKT63P58qbfeLJG8M5qcgTknrvvrdDbsT7Ml+tv82X6vVxJE33aRmgSyYtcWVMqX97Yv2JvW39UhRE2HuyBL+t+gK1116ly06EeWFNlAmHxlQE0OMiV6mQCScusKRlhS3QLeVJdl1+23h5dY4FNB3thrbYboqptEFlphTC1hSpJnbRvxP4NWgsE5Jyz86QNNi/5qSUTGuFk1gu54tN9wuK2wc3o+Wc13RCmsoBwEqzGcZsxsvCSy/9wJKf7UWf1mEY8JWfewc67UUoDbDjQC+FqK4QqLVMGGR9d2wurKzqBk3nqIT/9zLxRRjgZ9bqQgub+DdoeCC03Q8j+0QhFhBHR/eP3U/zCln7Uu+hihJ1+bBNffLIvmkyP0gpBZWYXhKussK6mBz5HT6M1Nqpcp+mBCPXosYQfrekGvrjewd59/GvKCE7TbK/04/ZV5QZYVWmDwH1mF3xa2Q3ra3DBC5vBT1oP7PTj4C0+CcL8c7C2CtejqhuCnuIQHaKHzvcRfZpnylFfXsYJx3pNLwhKzRAwAhEqG0SpusBHfAKkxw3w4627MPhoCH798z7s0ZnBJ/MEJbZSbXPhER2ih7p2ok/zSj2cEJDd4CAe+5WYnBCgR2uruyEw6zRoW6/DWJ/OeAP8pd/BGtzOZKpG8oke0SX6GMmRk6GFlyAc59K32OTEinILRJRchah8HQwND8N435Z9Z0FY1EqtxUg+0SO6RJ/mmXz4VuS+DpxXC3gXmZwIL7dBSH4zKE50wESf8qwVgrP1EIlTO5JP9Igu0aexdh28F1lmAEGJGfh7jE6ElyM5Rw/FDcYJjWhbeiBYoYNIpc2FT/SILivp0F1ipDWk4BIEo2VuodEJUifhbiltnNBIXPUFCMpthtAyqws/BPlEF/VbaIxErdxPphsU7rcCp8DohC+GvBIPJS/tW2jtvTmmAeuNO8BNOYQeG8G/2OzCJ3q+soYB5i6NhMaKr17FSal7GIHheuV3uSCY8qYVuEm1cOzqdWr7ku/R0BDoTT+DT+ohCM6/CCvKLKO4RI+dXPeAuaMqksaKrZ7L3FE5FIFbkIceeOZ2OcHO6wIhTkNo0ffgjRGxEqogXHYUPHfWAC/lADpwGcLRY3aeK4/oRGCKYcZXPVoeX/kelVYY8dUGf8V5EBRbgJXT5QIPhP9ePJi428JKOiEYhYXFBqou2Guh+p/mEB1/RfMw6rY7cxcjTrneI1FrDyuzUSRm9miwEJx8E/gUmqlyvHGkneiwErR21F3tNOK5Tf0yXaT+O7DgCvALTUBXdM4YhC/IawPU+2PduqMvuaR6eoxSwUk75ggqsYJ7VicsnwGIkZBSXKOUww73WGXyqP+J2/b9c+gi1YAg/xpwck3gJuucNrh5JvDPvQr0WFXf0piyt8f8/WI0hV4pRxxkQZdJDfDJNOAmM0Ag8jyT6hz0WGXWuP94Yh2jcfjmXAGvHCMslRimDHYuHuDsy2QtHuIavznhbYURq5R57KpzBBRZKPJi8eQg48h4j8SDdowifdIrEVdU+gbO6QNvRRt4ZBthUaZhUnjlYObNagV3keoeru3rU7rcuceqU1mJBxy+BWZYlNEBH+0eH4vRiB+OYybU2hnblYlTvkHinM4m54YnxSyaZYSF6R3jwgP7udKLGIX6r/lbNa9N6y5MFynjWDtrHd75ZvTYAPO/6RgF0k76mQla3FGq7dO+cH8sKn0Vo7nDllwAhqwLPkxrHwWmHJOo+AKJ4rab5OgrM7rVu8eWb2Pu0Dh4eDgXoOfvp7Y7QeqknRmvcTBEyq9m/HQQSCSz6LHq3z0yzsNySRfMS253wl2KyRDbcZPcfJKjZmSEOjcxyi+Y8dUOtsIEH6R2wNykdqrkYJ0RV92H0W58pkfQk7cKevsLK10Py8SdMGfXNXATY+pPbyJR/ET6n9nIfztNtZYRV9XniQu9IA2vOVgy4ir7GCLVmmd+zjkH0eAF9Po6K61pmCXHxU5rHMYd1ftc3owjwRSVRzLjKvqZEty6cRUD7jGqiOdu5HG6MdHjNcNYGqfDm5YRzLBBCCDl/2bk8a8gdbqcfwECu62Fg/HrggAAAABJRU5ErkJggg==",
@@ -27,24 +40,34 @@ var IconDefault = L.Icon.Default.extend(/** @lends IconDefault.prototype */ {
         // on merge les options avec celles par defaut
         L.Util.extend(this.options, options);
 
+        var _color = null;
+        var _images = /* (L.Browser.retina) ? this.images.retina : */ this.images;
         switch (color) {
             case "red":
-                this.options.iconUrl = this.images.color.red;
+                _color = _images.color.red;
                 break;
             case "green":
-                this.options.iconUrl = this.images.color.green;
+                _color = _images.color.green;
                 break;
             case "orange":
-                this.options.iconUrl = this.images.color.orange;
+                _color = _images.color.orange;
                 break;
             case "blue":
-                this.options.iconUrl = this.images.color.blue;
+                _color = _images.color.blue;
                 break;
             default:
-                this.options.iconUrl = this.images.color.blue;
+                _color = _images.color.blue;
         }
 
-        this.options.shadowUrl = this.images.shadow;
+        // icones classiques
+        this.options.iconUrl = _color;
+        this.options.shadowUrl = _images.shadow;
+
+        // icones pour écran Retina
+        if (L.Browser.retina) {
+            this.options.iconRetinaUrl = _color;
+            this.options.shadowRetinaUrl = _images.shadow;
+        }
     },
 
     /**


### PR DESCRIPTION
> Réaliser une recherche avec le widget *SearchEngine* Leaflet, et valider l'affichage du *marker*

À valider pour les **OS Mobile** avec l'URL suivante :
https://geoportail.000webhostapp.com/extensions/samples/leaflet/SearchEngine/pages-leaflet-searchengine-bundle-default.html