### PR TITLE
Update de jsdoc-webpack-plugin pour corriger le problème de compilation sur Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "handlebars-webpack-plugin": "^1.4.1",
     "html-webpack-plugin": "^3.1.0",
     "istanbul-instrumenter-loader": "^3.0.1",
-    "jsdoc-webpack-plugin": "0.0.1",
+    "jsdoc-webpack-plugin": "^0.1.0",
     "jsdom": "^9.9.1",
     "mocha": "^5.0.5",
     "mocha-loader": "^1.1.3",


### PR DESCRIPTION
Correction de #221 suite à [l'update ](https://github.com/MitkoTschimev/jsdoc-webpack-plugin/pull/14#issuecomment-485729493) du module npm en question