### PR TITLE
Prise en compte des options de geocoding du SearchEngine lors du geocoding "fallback"

### DIFF
--- a/src/OpenLayers/Controls/SearchEngine.js
+++ b/src/OpenLayers/Controls/SearchEngine.js
@@ -1261,7 +1261,7 @@ SearchEngine.prototype.onAutoCompleteSearchText = function (e) {
  */
 SearchEngine.prototype._getGeocodeCoordinatesFromFullText = function (suggestedLocation, i) {
     var context = this;
-    Gp.Services.geocode({
+    context._requestGeocoding({
         apiKey : this.options.apiKey,
         ssl : this.options.ssl,
         location : suggestedLocation.fullText,


### PR DESCRIPTION
Actuellement les paramètres de geocoding renseignés dans le SearchEngine sont ignorés (ex : proxyURL)

De ce que j'ai pu tester, il suffit d'utiliser `_requestGeocoding` utilisé ailleurs de la même manière dans le contrôle plutôt que d'appeler `Gp.Services.geocode` directement.