### PR TITLE
nouvelle méthode sur le widget Isocurve (ol)

### DIFF
--- a/samples-src/pages/openlayers/Isocurve/pages-ol-isocurve-bundle-drive.html
+++ b/samples-src/pages/openlayers/Isocurve/pages-ol-isocurve-bundle-drive.html
@@ -1,0 +1,60 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample openlayers Isocurve</title>
+{{/content}}
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout du widget de calcul isochrone, avec les options par défaut</h2>
+            <!-- map -->
+            <div id="map"></div>
+            <button type="button" id="compute">Calcul</button>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+
+              window.onload = function () {
+                // on cache l'image de chargement du Géoportail.
+                document.getElementById("map").style.backgroundImage = "none";
+
+                // Création de la map
+                var map = new ol.Map({
+                  target : "map",
+                  layers : [
+                    new ol.layer.GeoportalWMTS({
+                      layer : "GEOGRAPHICALGRIDSYSTEMS.MAPS"
+                    })
+                  ],
+                  view : new ol.View({
+                    center : [288074.8449901076, 6247982.515792289],
+                    zoom : 8
+                  })
+                });
+
+                var mouse = new ol.control.GeoportalMousePosition({});
+                map.addControl(mouse);
+                var iso = new ol.control.Isocurve({});
+                map.addControl(iso);
+
+                document.getElementById("compute").onclick = function(e) {
+                  iso.compute([288000, 6247900], "0.32", {
+                    direction : "arrival",
+                    method : "time",
+                    transport : "Pieton",
+                    exclusions : []
+                  });
+                }
+             };
+            </script>
+{{/content}}
+{{/extend}}

--- a/src/OpenLayers/Controls/Isocurve.js
+++ b/src/OpenLayers/Controls/Isocurve.js
@@ -188,6 +188,73 @@ var Isocurve = (function (Control) {
         Control.prototype.setMap.call(this, map);
     };
 
+    /**
+     * This method is public.
+     * It allows to control the execution of a traitment.
+     *
+     * @param {Object} position - position in the projection map
+     * @param {Object} value - distance in km or hours-minutes
+     * @param {Object} options - options = {...}
+     */
+    Isocurve.prototype.compute = function (position, value, options) {
+        this._clear();
+
+        if (!this._showIsoContainer.checked) {
+            this._pictoIsoContainer.click();
+        }
+
+        var map = this.getMap();
+        if (!map) {
+            return;
+        }
+
+        // Les options par defauts
+        var settings = {
+            direction : "departure",
+            method : "time",
+            transport : "Voiture",
+            exclusions : []
+        };
+
+        // On recupere les options
+        Utils.assign(settings, options);
+
+        this._originPoint.setCoordinate(position);
+        var coordinate = this._originPoint.getCoordinate();
+
+        var input = document.getElementById("GPlocationOrigin_" + 1 + "-" + this._uid);
+        input.value = coordinate[0].toFixed(4) + " / " + coordinate[1].toFixed(4);
+
+        this._currentTransport = settings.transport;
+        if (settings.transport === "Voiture") {
+            document.getElementById("GPisochronTransportCar-" + this._uid).checked = true;
+        } else {
+            document.getElementById("GPisochronTransportPedestrian-" + this._uid).checked = true;
+        }
+
+        this._currentExclusions = settings.exclusions;
+
+        this._currentComputation = settings.method;
+        if (settings.method === "time") {
+            var time = value.split(".");
+            this._currentTimeHour = time[0] || 0;
+            document.getElementById("GPisochronValueChronInput1-" + this._uid).value = this._currentTimeHour;
+            this._currentTimeMinute = time[1] || 0;
+            document.getElementById("GPisochronValueChronInput2-" + this._uid).value = this._currentTimeMinute;
+            document.getElementById("GPisochronChoiceAltChron-" + this._uid).click();
+        } else {
+            this._currentDistance = value;
+            document.getElementById("GPisochronValueDistInput-" + this._uid).value = this._currentDistance;
+            document.getElementById("GPisochronChoiceAltDist-" + this._uid).click();
+        }
+
+        this._currentDirection = settings.direction;
+        (settings.direction === "departure")
+            ? document.getElementById("GPisochronDirectionSelect-" + this._uid).selectedIndex = 0 : document.getElementById("GPisochronDirectionSelect-" + this._uid).selectedIndex = 1;
+
+        this.onIsoComputationSubmit();
+    };
+
     // ################################################################### //
     // ##################### init component ############################## //
     // ################################################################### //
@@ -256,6 +323,7 @@ var Isocurve = (function (Control) {
 
         // // containers principaux
         this._showIsoContainer = null;
+        this._pictoIsoContainer = null;
         this._waitingContainer = null;
         this._formContainer = null;
         this._IsoPanelContainer = null;
@@ -611,7 +679,7 @@ var Isocurve = (function (Control) {
             inputShow.checked = true;
         }
 
-        var picto = this._createShowIsoPictoElement();
+        var picto = this._pictoIsoContainer = this._createShowIsoPictoElement();
         container.appendChild(picto);
 
         // panneau

--- a/src/OpenLayers/Controls/Isocurve.js
+++ b/src/OpenLayers/Controls/Isocurve.js
@@ -192,7 +192,7 @@ var Isocurve = (function (Control) {
      * This method is public.
      * It allows to control the execution of a traitment.
      *
-     * @param {Object} position - position in the projection map
+     * @param {Array} position - position in the projection map [ x, y ]
      * @param {Object} value - distance in km or hours-minutes
      * @param {Object} options - options = {...}
      */

--- a/src/OpenLayers/Controls/LocationSelector.js
+++ b/src/OpenLayers/Controls/LocationSelector.js
@@ -223,6 +223,22 @@ var LocationSelector = (function (Control) {
     };
 
     /**
+     * set coordinate
+     * @param {Object} coordinate - Coordinate in the projection map
+     */
+    LocationSelector.prototype.setCoordinate = function (coordinate) {
+        var map = this.getMap();
+        var crs = map.getView().getProjection();
+
+        this._setCoordinate(coordinate, crs);
+
+        this._setMarker([
+            coordinate[0],
+            coordinate[1]
+        ], null, false);
+    };
+
+    /**
      * clean input
      */
     LocationSelector.prototype.clear = function () {


### PR DESCRIPTION
cf. issue #246 
nouvelle méthode publique sur le widget Isocurve qui permet de prépositionner un point sur la carte et de faire un traitement isochrone ou isodistance.

> Pour info, Leaflet implémente déjà ces méthodes publiques

**exemple**
```
var iso = new ol.control.Isocurve({});
iso.compute([288000, 6247900], "0.32", {
   direction : "arrival",
   method : "time",
   transport : "Pieton",
   exclusions : []
});
```

**jsdoc**
![gnome-shell-screenshot-YNM58Z](https://user-images.githubusercontent.com/10401006/66121022-7f21d400-e5dc-11e9-8b55-ca205aca5973.png)

**resultat** _cf. samples/openlayers/Isocurve/pages-ol-isocurve-bundle-drive.html_
![gnome-shell-screenshot-CXHC9Z](https://user-images.githubusercontent.com/10401006/66121115-b3959000-e5dc-11e9-81dd-90de3e6ba014.png)
