### PR TITLE
Ajout du tag "gp-itowns-ext" dans les requêtes WMTS et WMS via iTowns

### DIFF
--- a/src/Itowns/Layer/LayerElevation.js
+++ b/src/Itowns/Layer/LayerElevation.js
@@ -1,7 +1,9 @@
 /* globals self */
+import Gp from "geoportal-access-lib";
 import Utils from "../../Common/Utils";
 import Config from "../../Common/Utils/Config";
 import Logger from "../../Common/Utils/LoggerByDefault";
+import Pkg from "../../../package.json";
 import {
     Extent as ItExtent,
     WMTSSource as ItWMTSSource,
@@ -98,6 +100,11 @@ function LayerElevation (options) {
                 north : wmtsParams.extent.north
             }
         });
+
+        // ajout du tag gp-itowns-ext dans les requêtes WMTS elevation
+        config.source.url = Gp.Helper.normalyzeUrl(config.source.url, {
+            "gp-itowns-ext" : Pkg.itownsExtVersion || Pkg.version
+        }, false);
 
         // récupération des autres paramètres passés par l'utilisateur
         Utils.mergeParams(config, options.itownsParams);

--- a/src/Itowns/Layer/LayerWMS.js
+++ b/src/Itowns/Layer/LayerWMS.js
@@ -1,6 +1,8 @@
+import Gp from "geoportal-access-lib";
 import Utils from "../../Common/Utils";
 import Config from "../../Common/Utils/Config";
 import Logger from "../../Common/Utils/LoggerByDefault";
+import Pkg from "../../../package.json";
 import {
     Extent as ItExtent,
     WMSSource as ItWMSSource,
@@ -93,6 +95,11 @@ function LayerWMS (options) {
                 north : wmsParams.extent.north
             }
         });
+
+        // ajout du tag gp-itowns-ext dans les requêtes WMS
+        config.source.url = Gp.Helper.normalyzeUrl(config.source.url, {
+            "gp-itowns-ext" : Pkg.itownsExtVersion || Pkg.version
+        }, false);
 
         // récupération des autres paramètres passés par l'utilisateur
         Utils.mergeParams(config, options.itownsParams);

--- a/src/Itowns/Layer/LayerWMTS.js
+++ b/src/Itowns/Layer/LayerWMTS.js
@@ -1,6 +1,8 @@
+import Gp from "geoportal-access-lib";
 import Utils from "../../Common/Utils";
 import Config from "../../Common/Utils/Config";
 import Logger from "../../Common/Utils/LoggerByDefault";
+import Pkg from "../../../package.json";
 import {
     Extent as ItExtent,
     WMTSSource as ItWMTSSource,
@@ -96,6 +98,11 @@ function LayerWMTS (options) {
                 north : wmtsParams.extent.north
             }
         });
+
+        // ajout du tag gp-itowns-ext dans les requêtes WMTS
+        config.source.url = Gp.Helper.normalyzeUrl(config.source.url, {
+            "gp-itowns-ext" : Pkg.itownsExtVersion || Pkg.version
+        }, false);
 
         // récupération des autres paramètres passés par l'utilisateur
         Utils.mergeParams(config, options.itownsParams);


### PR DESCRIPTION
- tag gp-itowns-ext dans requêtes images envoyées via les extensions Gp pour itowns.
- numéro de version des extensions géoportail pour itowns visible dans tag

Utile pour : 
- compter les requêtes réalisée via les extensions géoportail pour itowns. 
- compter les utilisations des extensions itowns en fonction de leur version