### PR TITLE
Evolution de l'outil de dessins

### DIFF
--- a/samples-src/pages/itowns/Scale/pages-itowns-scale-amd.html
+++ b/samples-src/pages/itowns/Scale/pages-itowns-scale-amd.html
@@ -67,18 +67,6 @@
                         globeView.addLayer(layer);
                     };
 
-<<<<<<< HEAD
-                    
-=======
-                    itowns.Fetcher.json("{{ resources }}/itowns/JSONLayers/Ortho.json").then(createWMTSSourceFromConfig).then(addColorLayerFromConfig);
-
-                    itowns.Fetcher.json("{{ resources }}/itowns/JSONLayers/IGN_MNT.json").then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
-                    itowns.Fetcher.json("{{ resources }}/itowns/JSONLayers/IGN_MNT_HIGHRES.json").then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
-
-                    var scalebar = new Gp.itownsExtended.control.Scale({});
-                    globeView.addWidget( scalebar );
->>>>>>> a1e663d183159536a088dcf2c577a63a698f312e
-
                     globeView.listen(Gp.itownsExtended.GlobeViewExtended.EVENTS.GLOBE_INITIALIZED, () => {
                         // eslint-disable-next-line no-console
                         console.info("Globe initialized");

--- a/samples-src/pages/itowns/Scale/pages-itowns-scale-bundle.html
+++ b/samples-src/pages/itowns/Scale/pages-itowns-scale-bundle.html
@@ -58,12 +58,6 @@
                     globeView.addLayer(layer);
                 };
 
-<<<<<<< HEAD
-=======
-                var scalebar = new itowns.control.Scale({});
-                globeView.addWidget( scalebar );
-
->>>>>>> a1e663d183159536a088dcf2c577a63a698f312e
                 globeView.listen(itowns.GlobeViewExtended.EVENTS.GLOBE_INITIALIZED, () => {
                     console.info('Globe initialized');
 

--- a/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-all-options.html
+++ b/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-all-options.html
@@ -114,12 +114,18 @@
                       });
 
                       if (feature) {
-
+                          var message = "";
                           var coord = evt.coordinate;
                           var props = feature.getProperties();
+                          for (const property in props) {
+                              message += property;
+                              message += " : ";
+                              message += props[property];
+                              message += "<br>";
+                          }
                           // Offset the popup so it points at the middle of the marker not the tip
                           popup.setOffset([0, -22]);
-                          popup.show(coord, props);
+                          popup.show(coord, message);
 
                       }
                     });

--- a/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup-without-dom.html
+++ b/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup-without-dom.html
@@ -1,0 +1,97 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample OpenLayers Drawing</title>
+{{/content}}
+
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+                background-image:url("{{ resources }}/geoportail-waiting.gif");
+                background-position:center center;
+                background-repeat:no-repeat;
+            }
+            .ol-popup {
+                display: block;
+                position: absolute;
+                background-color: white;
+                padding: 15px 25px 15px 15px;
+                border: 1px solid #cccccc;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout des outils de dessin avec affichage des mesures</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                window.onload = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    //Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        layers : [new ol.layer.GeoportalWMTS({
+                            layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
+                        })],
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 8
+                        })
+                    });
+
+                    var drawing = new ol.control.Drawing({
+                        collapsed : true,
+                        popup : {
+                            display : true,
+                            function : function (params) {
+                                var element = document.createElement('div');
+                                element.className = "ol-popup";
+                                if (params.feature) {
+                                    var message = "";
+                                    var props = params.feature.getProperties();
+                                    for (const property in props) {
+                                        // properties de sauvegarde
+                                        if (property === "description") {
+                                            continue;
+                                        }
+                                        message += property;
+                                        message += " : ";
+                                        message += props[property];
+                                        message += "<br>";
+                                    }
+                                    element.innerHTML = message;
+                                    // sauvegarde du contenu dans la feature !
+                                    params.feature.setProperties({
+                                        description : message
+                                    });
+                                }
+                                // on retourne un dom minimal
+                                return element;
+                            }
+                        },
+                    });
+
+                    drawing.on(
+                        "change:collapsed",
+                        function (e) {
+                            console.log("change:collapsed : collapsed =", e.target.collapsed);
+                        }
+                    );
+
+                    map.addControl(drawing);
+                };
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
+++ b/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
@@ -1,0 +1,77 @@
+{{#extend "ol-sample-bundle-layout"}}
+
+{{#content "head"}}
+        <title>Sample OpenLayers Drawing</title>
+{{/content}}
+
+
+{{#content "style"}}
+        <style>
+            div#map {
+                width: 100%;
+                height: 500px;
+                background-image:url("{{ resources }}/geoportail-waiting.gif");
+                background-position:center center;
+                background-repeat:no-repeat;
+            }
+        </style>
+{{/content}}
+
+{{#content "body"}}
+            <h2>Ajout des outils de dessin avec affichage des mesures</h2>
+            <!-- map -->
+            <div id="map">
+            </div>
+{{/content}}
+
+{{#content "js"}}
+            <script type="text/javascript">
+                var map;
+                var createMap = function() {
+                    // on cache l'image de chargement du Géoportail.
+                    document.getElementById('map').style.backgroundImage = 'none';
+
+                    //Création de la map
+                    map = new ol.Map({
+                        target : "map",
+                        layers : [new ol.layer.GeoportalWMTS({
+                            layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
+                        })],
+                        view : new ol.View({
+                            center : [288074.8449901076, 6247982.515792289],
+                            zoom : 8
+                        })
+                    });
+
+                    var drawing = new ol.control.Drawing({
+                        collapsed : true,
+                        popup : {
+                            display : true,
+                            apply : function ({geomType : geomType, feature : feature}) {
+                                console.log(geomType);
+                                var props = feature.getProperties();
+                                console.log(props);
+                            }
+                        },
+                    });
+
+                    drawing.on(
+                        "change:collapsed",
+                        function (e) {
+                            console.log("change:collapsed : collapsed =", e.target.collapsed);
+                        }
+                    );
+
+                    map.addControl(drawing);
+                };
+                Gp.Services.getConfig({
+                    serverUrl : "{{ resources }}/AutoConf.js",
+                    callbackSuffix : "",
+                    // apiKey: "jhyvi0fgmnuxvfv0zjzorvdn",
+                    timeOut : 20000,
+                    onSuccess : createMap
+                });
+           </script>
+{{/content}}
+
+{{/extend}}

--- a/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
+++ b/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
@@ -14,6 +14,21 @@
                 background-position:center center;
                 background-repeat:no-repeat;
             }
+            .ol-popup {
+                display: block;
+                position: absolute;
+                background-color: white;
+                padding: 15px 25px 15px 15px;
+                border: 1px solid #cccccc;
+                bottom: 12px;
+                left: -50px;
+            }
+            .ol-popup-content {
+                min-width: 170px;
+                max-height: 200px;
+                overflow-x: auto;
+            }
+
         </style>
 {{/content}}
 
@@ -27,7 +42,7 @@
 {{#content "js"}}
             <script type="text/javascript">
                 var map;
-                var createMap = function() {
+                window.onload = function() {
                     // on cache l'image de chargement du Géoportail.
                     document.getElementById('map').style.backgroundImage = 'none';
 
@@ -48,9 +63,26 @@
                         popup : {
                             display : true,
                             apply : function ({geomType : geomType, feature : feature}) {
+                                var element = document.createElement('div');
+                                element.className = "ol-popup";
                                 console.log(geomType);
                                 var props = feature.getProperties();
                                 console.log(props);
+                                if (feature) {
+                                    var message = "";
+                                    var props = feature.getProperties();
+                                    for (const property in props) {
+                                        message += property;
+                                        message += " : ";
+                                        message += props[property];
+                                        message += "<br>";
+                                    }
+                                    var content = document.createElement('div');
+                                    content.className = "ol-popup-content";
+                                    content.innerHTML = message;
+                                    element.appendChild(content);
+                                }
+                                return element;
                             }
                         },
                     });
@@ -64,13 +96,6 @@
 
                     map.addControl(drawing);
                 };
-                Gp.Services.getConfig({
-                    serverUrl : "{{ resources }}/AutoConf.js",
-                    callbackSuffix : "",
-                    // apiKey: "jhyvi0fgmnuxvfv0zjzorvdn",
-                    timeOut : 20000,
-                    onSuccess : createMap
-                });
            </script>
 {{/content}}
 

--- a/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
+++ b/samples-src/pages/openlayers/Drawing/pages-ol-drawing-bundle-options-popup.html
@@ -20,15 +20,21 @@
                 background-color: white;
                 padding: 15px 25px 15px 15px;
                 border: 1px solid #cccccc;
-                bottom: 12px;
-                left: -50px;
             }
             .ol-popup-content {
                 min-width: 170px;
                 max-height: 200px;
                 overflow-x: auto;
             }
-
+            .ol-popup-closer {
+                position: absolute;
+                top: 2px;
+                right: 2px;
+                color: gray;
+            }
+            .ol-popup-saver {
+                position: absolute;
+            }
         </style>
 {{/content}}
 
@@ -62,25 +68,48 @@
                         collapsed : true,
                         popup : {
                             display : true,
-                            apply : function ({geomType : geomType, feature : feature}) {
+                            function : function (params) {
                                 var element = document.createElement('div');
                                 element.className = "ol-popup";
-                                console.log(geomType);
-                                var props = feature.getProperties();
-                                console.log(props);
-                                if (feature) {
+                                // liste des params
+                                console.log(params.geomType);
+                                console.log(params.feature);
+                                if (params.feature) {
                                     var message = "";
-                                    var props = feature.getProperties();
+                                    var props = params.feature.getProperties();
                                     for (const property in props) {
+                                        // properties de sauvegarde
+                                        if (property === "description") {
+                                            continue;
+                                        }
                                         message += property;
                                         message += " : ";
                                         message += props[property];
                                         message += "<br>";
                                     }
+                                    // element de fermeture
+                                    var closer = document.createElement('input');
+                                    closer.type = "button";
+                                    closer.value = "X";
+                                    closer.className = 'ol-popup-closer';
+                                    closer.onclick = function () {
+                                        params.closeFunc();
+                                    };
+                                    element.appendChild(closer);
+                                    // contenu
                                     var content = document.createElement('div');
                                     content.className = "ol-popup-content";
                                     content.innerHTML = message;
                                     element.appendChild(content);
+                                    // element de sauvegarde
+                                    var save = document.createElement('input');
+                                    save.type = "button";
+                                    save.value = "Sauvegarde";
+                                    save.className = 'ol-popup-saver';
+                                    save.onclick = function () {
+                                        params.saveFunc(message);
+                                    };
+                                    element.appendChild(save);
                                 }
                                 return element;
                             }

--- a/samples-src/pages/openlayers/GetFeatureInfo/pages-ol-getfeatureinfo-bundle-options.html
+++ b/samples-src/pages/openlayers/GetFeatureInfo/pages-ol-getfeatureinfo-bundle-options.html
@@ -232,6 +232,9 @@
                 }
             });
             map.addControl(layerSwitcher);
+
+            var iso = new ol.control.Isocurve({});
+            map.addControl(iso);
         }
     </script>
 {{/content}}

--- a/src/Common/Controls/DrawingDOM.js
+++ b/src/Common/Controls/DrawingDOM.js
@@ -171,6 +171,14 @@ var DrawingDOM = {
                 id : "polygon"
             };
         }
+        if (this.options.tools.holes) {
+            this.dtOptions.holes = {
+                label : this.options.labels.holes,
+                active : false,
+                panel : "draw",
+                id : "holes"
+            };
+        }
         if (this.options.tools.text) {
             this.dtOptions.text = {
                 label : this.options.labels.text,

--- a/src/OpenLayers/CSS/Controls/Drawing/GPdrawingOpenLayers.css
+++ b/src/OpenLayers/CSS/Controls/Drawing/GPdrawingOpenLayers.css
@@ -92,6 +92,14 @@ li[id^=drawing-tool-line.drawing-tool-active-] {
     background-position: -120px 0;
 }
 
+li[id^=drawing-tool-holes-] {
+    background-position: -160px 0;
+}
+
+li[id^=drawing-tool-holes.drawing-tool-active] {
+    background-position: -200px 0;
+}
+
 li[id^=drawing-tool-polygon-] {
     background-position: -160px 0;
 }

--- a/src/OpenLayers/CSS/Controls/Drawing/GPdrawingOpenLayers.css
+++ b/src/OpenLayers/CSS/Controls/Drawing/GPdrawingOpenLayers.css
@@ -61,7 +61,7 @@ ul.drawing-tools-flex-display {
 
 .drawing-tool {
     background-image: url("img/drawing-tools.svg");
-    background-size: 640px 40px;
+    background-size: 720px 40px;
 }
 
 .drawing-tool {
@@ -93,11 +93,11 @@ li[id^=drawing-tool-line.drawing-tool-active-] {
 }
 
 li[id^=drawing-tool-holes-] {
-    background-position: -160px 0;
+    background-position: -640px 0;
 }
 
 li[id^=drawing-tool-holes.drawing-tool-active] {
-    background-position: -200px 0;
+    background-position: -680px 0;
 }
 
 li[id^=drawing-tool-polygon-] {

--- a/src/OpenLayers/CSS/Controls/Drawing/img/drawing-tools.svg
+++ b/src/OpenLayers/CSS/Controls/Drawing/img/drawing-tools.svg
@@ -1,1 +1,452 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="40" width="640" viewBox="0 0 640.00001 40.000001"><defs><clipPath id="b"><path d="M0 896h896V0H0v896z"/></clipPath><clipPath id="a"><path d="M0 896h896V0H0v896z"/></clipPath></defs><path d="M87.43 32.526l5-15 15 10 5-20" stroke="#00b798" stroke-width="2" fill="none"/><g fill-rule="evenodd" stroke="#e9edf0" stroke-width="1.5" fill="#00b798"><path d="M85.942 30.062v4h4v-4zM90.765 15.946v4h4v-4zM105.29 25.118v4h4v-4zM110.06 5.938v4h4v-4z"/></g><path d="M127.43 32.526l5-15 15 10 5-20" stroke="#fff" stroke-width="2" fill="none"/><g fill-rule="evenodd" stroke="#002a50" stroke-width="1.5" fill="#fff"><path d="M125.94 30.062v4h4v-4zM130.77 15.946v4h4v-4zM145.29 25.118v4h4v-4zM150.06 5.938v4h4v-4z"/></g><g fill-rule="evenodd" fill="#00b798"><path d="M168.31 29.938l3-19.875 14.75-3 5 25.875z" fill-opacity=".4" stroke="#00b798" stroke-width="2"/><g stroke="#e9edf0" stroke-width="1.5"><path d="M183.94 5.063v4h4v-4zM169.19 8.313v4h4v-4zM166.31 27.938v4h4v-4zM189.69 30.938v4h4v-4z"/></g></g><g fill-rule="evenodd" fill="#fff"><path d="M208.31 29.938l3-19.875 14.75-3 5 25.875z" fill-opacity=".4" stroke="#fff" stroke-width="2"/><g stroke="#002a50" stroke-width="1.5"><path d="M223.94 5.063v4h4v-4zM209.19 8.313v4h4v-4zM206.31 27.938v4h4v-4zM229.69 30.938v4h4v-4z"/></g></g><path d="M261.81 30.74l-1.553-5.098h-7.807l-1.553 5.098h-4.893l7.56-21.504h5.55l7.59 21.504h-4.894zm-2.637-8.906q-2.153-6.93-2.43-7.837-.265-.908-.382-1.436-.483 1.876-2.768 9.274h5.58z" fill="#00b798"/><g stroke="#00b798" fill="none"><path d="M271.5 31.04v-22"/><path d="M269 8.56h5M269 31.44h5" stroke-width="1.118"/></g><text font-size="12.5" y="30.752" x="286" font-family="sans-serif" fill="#fff" word-spacing="0" letter-spacing="0"><tspan font-weight="bold" font-size="30" y="30.752" x="286" font-family="'Open Sans'">A</tspan></text><g stroke="#fff" fill="none"><path d="M311.5 31.04v-22"/><path d="M309 8.56h5M309 31.44h5" stroke-width="1.118"/></g><path d="M356.64 21.782l-3.416-3.414c-.472-.47-1.236-.47-1.708 0l-.854.854c-.47.47-.47 1.235 0 1.706l3.416 3.414c.472.47 1.236.47 1.708 0l.854-.853c.472-.473.472-1.237 0-1.708m-10.714 10.93c-.005 0-.012.01-.02.013-.004 0-.01.01-.014.01-.005 0-.01.01-.016.01-.005 0-.01.01-.017.01-.2.12-.783.425-2.2.937-.165.06-.345.123-.534.19l-2.014-2.013c.066-.19.13-.373.19-.54.51-1.42.818-2.004.936-2.202.003 0 .006-.01.008-.013.004-.01.008-.013.012-.02.003 0 .006-.01.008-.012.005-.01.01-.014.013-.02l.146-.147 3.65 3.647-.15.15zm3.882-10.93c-.47-.47-1.236-.47-1.708 0l-.427.427-5.977 5.973h.002l-.19.188s-.6.605-1.956 4.976c-.01.03-.02.06-.028.092-.024.078-.05.158-.074.24-.02.07-.043.143-.066.216l-.056.186-.13.44c-.098.33-.336 1.074-.067 1.343.26.26 1.014.03 1.343-.066l.437-.13.194-.06c.07-.02.137-.04.205-.062l.25-.077c.025-.01.05-.015.073-.023 4.166-1.295 4.914-1.903 4.976-1.96h.004l.193-.192.012.013 5.977-5.974.427-.427c.472-.47.472-1.235 0-1.707l-3.416-3.414z" fill="#00b798"/><path d="M329 8l-2 2v16l2 2h10l8-8V10l-2-2z" fill-rule="evenodd" fill="#00b798"/><g fill="#fff"><path d="M396.64 21.782l-3.416-3.414c-.472-.47-1.236-.47-1.708 0l-.854.854c-.47.47-.47 1.235 0 1.706l3.416 3.414c.472.47 1.236.47 1.708 0l.854-.853c.472-.473.472-1.237 0-1.708m-10.714 10.93c-.005 0-.012.01-.02.013-.004 0-.01.01-.014.01-.005 0-.01.01-.016.01-.005 0-.01.01-.017.01-.2.12-.783.425-2.2.937-.165.06-.345.123-.534.19l-2.014-2.013c.066-.19.13-.373.19-.54.51-1.42.818-2.004.936-2.202.003 0 .006-.01.008-.013.004-.01.008-.013.012-.02.003 0 .006-.01.008-.012.005-.01.01-.014.013-.02l.146-.147 3.65 3.647-.15.15zm3.882-10.93c-.47-.47-1.236-.47-1.708 0l-.427.427-5.977 5.973h.002l-.19.188s-.6.605-1.956 4.976c-.01.03-.02.06-.028.092-.024.078-.05.158-.074.24-.02.07-.043.143-.066.216l-.056.186-.13.44c-.098.33-.336 1.074-.067 1.343.26.26 1.014.03 1.343-.066l.437-.13.194-.06c.07-.02.137-.04.205-.062l.25-.077c.025-.01.05-.015.073-.023 4.166-1.295 4.914-1.903 4.976-1.96h.004l.193-.192.012.013 5.977-5.974.427-.427c.472-.47.472-1.235 0-1.707l-3.416-3.414z" stroke="#eff" stroke-width=".03"/><path d="M369 8l-2 2v16l2 2h10l8-8V10l-2-2zM460.53 23.97c-3.16 1.63-1.157 5.534-4.74 6.803-3.763 1.334-6.892-3.492-7.676-6.963-.3-1.333-.92-12.314 11.138-14.593 9.407-1.778 12.657 7.854 12.72 10.89.058 2.89.37 9.04-4.44 8.962-4.06-.066-3.203-4.064-6.88-5.038-1.956-.518-.122-.062-.122-.062z" fill-rule="evenodd"/></g><ellipse rx="2.438" ry="2.5" cy="24.812" cx="454.19" fill="#002a50"/><g stroke="#002a50" stroke-linecap="round" stroke-width="1.736" fill="none"><path d="M452.78 18.54l4.34-2.604M453.64 16.81l2.604-1.736M454.51 18.54l1.736-.868"/><g><path d="M461.47 17.13l4.34-2.604M462.34 15.39l2.604-1.736M463.21 17.13l1.736-.868"/></g><g><path d="M464.91 23.22l4.34-2.604M465.77 21.48l2.604-1.736M466.64 23.22l1.736-.868"/></g></g><path d="M420.53 23.97c-3.16 1.63-1.157 5.534-4.74 6.803-3.763 1.334-6.892-3.492-7.676-6.963-.3-1.333-.92-12.314 11.138-14.593 9.407-1.778 12.657 7.854 12.72 10.89.058 2.89.37 9.04-4.44 8.962-4.06-.066-3.203-4.064-6.88-5.038-1.956-.518-.122-.062-.122-.062z" fill-rule="evenodd" fill="#00b798"/><ellipse rx="2.438" ry="2.5" cy="24.812" cx="414.19" fill="#e9edf0"/><g stroke="#edeff0" stroke-linecap="round" stroke-width="1.736" fill="none"><path d="M412.78 18.54l4.34-2.604M413.64 16.81l2.604-1.736M414.51 18.54l1.736-.868"/><g><path d="M421.47 17.13l4.34-2.604M422.34 15.39l2.604-1.736M423.21 17.13l1.736-.868"/></g><g><path d="M424.91 23.22l4.34-2.604M425.77 21.48l2.604-1.736M426.64 23.22l1.736-.868"/></g></g><g clip-path="url(#a)" transform="matrix(.02976 0 0 -.02902 6.667 33)" fill="#00b798"><path d="M448 448c-61.772 0-112 50.23-112 112s50.228 112 112 112c61.77 0 112-50.23 112-112s-50.23-112-112-112m0 448c-185.28 0-336-150.72-336-336 0-70.587 21.958-138.3 63.424-195.89l8.818-12.36 241.36-340.54C430.898 4.16 439.212 0 448.002 0c8.788 0 17.102 4.157 22.394 11.21l238.36 336.49 11.76 16.3c41.53 57.697 63.49 125.41 63.49 196 0 185.28-150.72 336-336 336"/></g><g clip-path="url(#b)" transform="matrix(.02976 0 0 -.02902 46.667 33)" fill="#fff"><path d="M448 448c-61.772 0-112 50.23-112 112s50.228 112 112 112c61.77 0 112-50.23 112-112s-50.23-112-112-112m0 448c-185.28 0-336-150.72-336-336 0-70.587 21.958-138.3 63.424-195.89l8.818-12.36 241.36-340.54C430.898 4.16 439.212 0 448.002 0c8.788 0 17.102 4.157 22.394 11.21l238.36 336.49 11.76 16.3c41.53 57.697 63.49 125.41 63.49 196 0 185.28-150.72 336-336 336"/></g><g stroke-linejoin="round" stroke="#fff" stroke-linecap="round" fill="none" stroke-width="3.814"><path d="M611.93 11.93l16.148 16.148M628.07 11.93l-16.148 16.148"/></g><g stroke-linejoin="round" stroke="#00b798" stroke-linecap="round" fill="none" stroke-width="3.814"><path d="M571.93 11.93l16.148 16.148M588.07 11.93l-16.148 16.148"/></g><path d="M487 30.04l1.004-6L493 29.03z" fill-rule="evenodd" fill="#00b798"/><g fill="#00b798" transform="translate(-48 -972.36)"><circle cx="541" cy="987.36" r="5"/><circle cx="555" cy="987.36" r="5"/><circle cx="555" cy="996.36" r="5"/><rect rx="0" ry="0" height="11" width="14" y="982.36" x="541"/><path d="M550 987.36h10v9h-10z"/><path d="M544 993.36h11v8h-11zM536 987.36h7v6h-7z"/><path d="M536 993.36l8 8v-8z" fill-rule="evenodd"/></g><g fill="#edeff0"><path d="M493 14h15v1h-15zM493 18h15v1h-15zM496 22h12v1h-12z"/></g><path d="M527 30l1.004-6L533 28.99z" fill-rule="evenodd" fill="#fff"/><g fill="#fff" transform="translate(-8 -972.36)"><circle cy="987.36" cx="541" r="5"/><circle cy="987.36" cx="555" r="5"/><circle cy="996.36" cx="555" r="5"/><rect rx="0" ry="0" height="11" width="14" y="982.36" x="541"/><path d="M550 987.36h10v9h-10z"/><path d="M544 993.36h11v8h-11zM536 987.36h7v6h-7z"/><path d="M536 993.36l8 8v-8z" fill-rule="evenodd"/></g><g fill="#002a50"><path d="M533 14h15v1h-15zM533 18h15v1h-15zM536 22h12v1h-12z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="40"
+   width="720"
+   viewBox="0 0 720.00001 40.000001"
+   version="1.1"
+   id="svg156"
+   sodipodi:docname="drawing-tools.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata160">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1312"
+     inkscape:window-height="708"
+     id="namedview158"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="6.6114484"
+     inkscape:cx="655.21554"
+     inkscape:cy="24.530385"
+     inkscape:window-x="54"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg156" />
+  <defs
+     id="defs8">
+    <clipPath
+       id="b">
+      <path
+         d="M 0,896 H 896 V 0 H 0 Z"
+         id="path2"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       id="a">
+      <path
+         d="M 0,896 H 896 V 0 H 0 Z"
+         id="path5"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+  </defs>
+  <path
+     d="m 87.43,32.526 5,-15 15,10 5,-20"
+     id="path10"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#00b798;stroke-width:2" />
+  <g
+     id="g14"
+     style="fill:#00b798;fill-rule:evenodd;stroke:#e9edf0;stroke-width:1.5">
+    <path
+       d="m 85.942,30.062 v 4 h 4 v -4 z m 4.823,-14.116 v 4 h 4 v -4 z m 14.525,9.172 v 4 h 4 v -4 z m 4.77,-19.18 v 4 h 4 v -4 z"
+       id="path12"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     d="m 127.43,32.526 5,-15 15,10 5,-20"
+     id="path16"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#ffffff;stroke-width:2" />
+  <g
+     id="g20"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#002a50;stroke-width:1.5">
+    <path
+       d="m 125.94,30.062 v 4 h 4 v -4 z m 4.83,-14.116 v 4 h 4 v -4 z m 14.52,9.172 v 4 h 4 v -4 z m 4.77,-19.18 v 4 h 4 v -4 z"
+       id="path18"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g28"
+     style="fill:#00b798;fill-rule:evenodd">
+    <path
+       d="m 168.31,29.938 3,-19.875 14.75,-3 5,25.875 z"
+       id="path22"
+       inkscape:connector-curvature="0"
+       style="fill-opacity:0.4;stroke:#00b798;stroke-width:2" />
+    <g
+       id="g26"
+       style="stroke:#e9edf0;stroke-width:1.5">
+      <path
+         d="m 183.94,5.063 v 4 h 4 v -4 z m -14.75,3.25 v 4 h 4 v -4 z m -2.88,19.625 v 4 h 4 v -4 z m 23.38,3 v 4 h 4 v -4 z"
+         id="path24"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     id="g36"
+     style="fill:#ffffff;fill-rule:evenodd">
+    <path
+       d="m 208.31,29.938 3,-19.875 14.75,-3 5,25.875 z"
+       id="path30"
+       inkscape:connector-curvature="0"
+       style="fill-opacity:0.4;stroke:#ffffff;stroke-width:2" />
+    <g
+       id="g34"
+       style="stroke:#002a50;stroke-width:1.5">
+      <path
+         d="m 223.94,5.063 v 4 h 4 v -4 z m -14.75,3.25 v 4 h 4 v -4 z m -2.88,19.625 v 4 h 4 v -4 z m 23.38,3 v 4 h 4 v -4 z"
+         id="path32"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     d="m 261.81,30.74 -1.553,-5.098 h -7.807 l -1.553,5.098 h -4.893 l 7.56,-21.504 h 5.55 l 7.59,21.504 z m -2.637,-8.906 q -2.153,-6.93 -2.43,-7.837 -0.265,-0.908 -0.382,-1.436 -0.483,1.876 -2.768,9.274 h 5.58 z"
+     id="path38"
+     inkscape:connector-curvature="0"
+     style="fill:#00b798" />
+  <g
+     id="g44"
+     style="fill:none;stroke:#00b798">
+    <path
+       d="m 271.5,31.04 v -22"
+       id="path40"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 269,8.56 h 5 m -5,22.88 h 5"
+       id="path42"
+       inkscape:connector-curvature="0"
+       style="stroke-width:1.11800003" />
+  </g>
+  <text
+     font-size="12.5"
+     y="30.752001"
+     x="286"
+     word-spacing="0"
+     letter-spacing="0"
+     id="text48"
+     style="font-size:12.5px;font-family:sans-serif;letter-spacing:0;word-spacing:0;fill:#ffffff">
+    <tspan
+       font-weight="bold"
+       font-size="30"
+       y="30.752001"
+       x="286"
+       id="tspan46"
+       style="font-weight:bold;font-size:30px;font-family:'Open Sans'">A</tspan>
+  </text>
+  <g
+     id="g54"
+     style="fill:none;stroke:#ffffff">
+    <path
+       d="m 311.5,31.04 v -22"
+       id="path50"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 309,8.56 h 5 m -5,22.88 h 5"
+       id="path52"
+       inkscape:connector-curvature="0"
+       style="stroke-width:1.11800003" />
+  </g>
+  <path
+     d="m 356.64,21.782 -3.416,-3.414 c -0.472,-0.47 -1.236,-0.47 -1.708,0 l -0.854,0.854 c -0.47,0.47 -0.47,1.235 0,1.706 l 3.416,3.414 c 0.472,0.47 1.236,0.47 1.708,0 l 0.854,-0.853 c 0.472,-0.473 0.472,-1.237 0,-1.708 m -10.714,10.93 c -0.005,0 -0.012,0.01 -0.02,0.013 -0.004,0 -0.01,0.01 -0.014,0.01 -0.005,0 -0.01,0.01 -0.016,0.01 -0.005,0 -0.01,0.01 -0.017,0.01 -0.2,0.12 -0.783,0.425 -2.2,0.937 -0.165,0.06 -0.345,0.123 -0.534,0.19 l -2.014,-2.013 c 0.066,-0.19 0.13,-0.373 0.19,-0.54 0.51,-1.42 0.818,-2.004 0.936,-2.202 0.003,0 0.006,-0.01 0.008,-0.013 0.004,-0.01 0.008,-0.013 0.012,-0.02 0.003,0 0.006,-0.01 0.008,-0.012 0.005,-0.01 0.01,-0.014 0.013,-0.02 l 0.146,-0.147 3.65,3.647 -0.15,0.15 z m 3.882,-10.93 c -0.47,-0.47 -1.236,-0.47 -1.708,0 l -0.427,0.427 -5.977,5.973 h 0.002 l -0.19,0.188 c 0,0 -0.6,0.605 -1.956,4.976 -0.01,0.03 -0.02,0.06 -0.028,0.092 -0.024,0.078 -0.05,0.158 -0.074,0.24 -0.02,0.07 -0.043,0.143 -0.066,0.216 l -0.056,0.186 -0.13,0.44 c -0.098,0.33 -0.336,1.074 -0.067,1.343 0.26,0.26 1.014,0.03 1.343,-0.066 l 0.437,-0.13 0.194,-0.06 c 0.07,-0.02 0.137,-0.04 0.205,-0.062 l 0.25,-0.077 c 0.025,-0.01 0.05,-0.015 0.073,-0.023 4.166,-1.295 4.914,-1.903 4.976,-1.96 h 0.004 l 0.193,-0.192 0.012,0.013 5.977,-5.974 0.427,-0.427 c 0.472,-0.47 0.472,-1.235 0,-1.707 l -3.416,-3.414 z"
+     id="path56"
+     inkscape:connector-curvature="0"
+     style="fill:#00b798" />
+  <path
+     d="m 329,8 -2,2 v 16 l 2,2 h 10 l 8,-8 V 10 l -2,-2 z"
+     id="path58"
+     inkscape:connector-curvature="0"
+     style="fill:#00b798;fill-rule:evenodd" />
+  <g
+     id="g64"
+     style="fill:#ffffff">
+    <path
+       d="m 396.64,21.782 -3.416,-3.414 c -0.472,-0.47 -1.236,-0.47 -1.708,0 l -0.854,0.854 c -0.47,0.47 -0.47,1.235 0,1.706 l 3.416,3.414 c 0.472,0.47 1.236,0.47 1.708,0 l 0.854,-0.853 c 0.472,-0.473 0.472,-1.237 0,-1.708 m -10.714,10.93 c -0.005,0 -0.012,0.01 -0.02,0.013 -0.004,0 -0.01,0.01 -0.014,0.01 -0.005,0 -0.01,0.01 -0.016,0.01 -0.005,0 -0.01,0.01 -0.017,0.01 -0.2,0.12 -0.783,0.425 -2.2,0.937 -0.165,0.06 -0.345,0.123 -0.534,0.19 l -2.014,-2.013 c 0.066,-0.19 0.13,-0.373 0.19,-0.54 0.51,-1.42 0.818,-2.004 0.936,-2.202 0.003,0 0.006,-0.01 0.008,-0.013 0.004,-0.01 0.008,-0.013 0.012,-0.02 0.003,0 0.006,-0.01 0.008,-0.012 0.005,-0.01 0.01,-0.014 0.013,-0.02 l 0.146,-0.147 3.65,3.647 -0.15,0.15 z m 3.882,-10.93 c -0.47,-0.47 -1.236,-0.47 -1.708,0 l -0.427,0.427 -5.977,5.973 h 0.002 l -0.19,0.188 c 0,0 -0.6,0.605 -1.956,4.976 -0.01,0.03 -0.02,0.06 -0.028,0.092 -0.024,0.078 -0.05,0.158 -0.074,0.24 -0.02,0.07 -0.043,0.143 -0.066,0.216 l -0.056,0.186 -0.13,0.44 c -0.098,0.33 -0.336,1.074 -0.067,1.343 0.26,0.26 1.014,0.03 1.343,-0.066 l 0.437,-0.13 0.194,-0.06 c 0.07,-0.02 0.137,-0.04 0.205,-0.062 l 0.25,-0.077 c 0.025,-0.01 0.05,-0.015 0.073,-0.023 4.166,-1.295 4.914,-1.903 4.976,-1.96 h 0.004 l 0.193,-0.192 0.012,0.013 5.977,-5.974 0.427,-0.427 c 0.472,-0.47 0.472,-1.235 0,-1.707 l -3.416,-3.414 z"
+       id="path60"
+       inkscape:connector-curvature="0"
+       style="stroke:#eeffff;stroke-width:0.03" />
+    <path
+       d="m 369,8 -2,2 v 16 l 2,2 h 10 l 8,-8 V 10 l -2,-2 z m 91.53,15.97 c -3.16,1.63 -1.157,5.534 -4.74,6.803 -3.763,1.334 -6.892,-3.492 -7.676,-6.963 -0.3,-1.333 -0.92,-12.314 11.138,-14.593 9.407,-1.778 12.657,7.854 12.72,10.89 0.058,2.89 0.37,9.04 -4.44,8.962 -4.06,-0.066 -3.203,-4.064 -6.88,-5.038 -1.956,-0.518 -0.122,-0.062 -0.122,-0.062 z"
+       id="path62"
+       inkscape:connector-curvature="0"
+       style="fill-rule:evenodd" />
+  </g>
+  <ellipse
+     rx="2.438"
+     ry="2.5"
+     cy="24.812"
+     cx="454.19"
+     id="ellipse66"
+     style="fill:#002a50" />
+  <g
+     id="g78"
+     style="fill:none;stroke:#002a50;stroke-width:1.73599994;stroke-linecap:round">
+    <path
+       d="m 452.78,18.54 4.34,-2.604 m -3.48,0.874 2.604,-1.736 m -1.734,3.466 1.736,-0.868"
+       id="path68"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g72">
+      <path
+         d="m 461.47,17.13 4.34,-2.604 m -3.47,0.864 2.604,-1.736 m -1.734,3.476 1.736,-0.868"
+         id="path70"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g76">
+      <path
+         d="m 464.91,23.22 4.34,-2.604 m -3.48,0.864 2.604,-1.736 m -1.734,3.476 1.736,-0.868"
+         id="path74"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     d="m 420.53,23.97 c -3.16,1.63 -1.157,5.534 -4.74,6.803 -3.763,1.334 -6.892,-3.492 -7.676,-6.963 -0.3,-1.333 -0.92,-12.314 11.138,-14.593 9.407,-1.778 12.657,7.854 12.72,10.89 0.058,2.89 0.37,9.04 -4.44,8.962 -4.06,-0.066 -3.203,-4.064 -6.88,-5.038 -1.956,-0.518 -0.122,-0.062 -0.122,-0.062 z"
+     id="path80"
+     inkscape:connector-curvature="0"
+     style="fill:#00b798;fill-rule:evenodd" />
+  <ellipse
+     rx="2.438"
+     ry="2.5"
+     cy="24.812"
+     cx="414.19"
+     id="ellipse82"
+     style="fill:#e9edf0" />
+  <g
+     id="g94"
+     style="fill:none;stroke:#edeff0;stroke-width:1.73599994;stroke-linecap:round">
+    <path
+       d="m 412.78,18.54 4.34,-2.604 m -3.48,0.874 2.604,-1.736 m -1.734,3.466 1.736,-0.868"
+       id="path84"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g88">
+      <path
+         d="m 421.47,17.13 4.34,-2.604 m -3.47,0.864 2.604,-1.736 m -1.734,3.476 1.736,-0.868"
+         id="path86"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g92">
+      <path
+         d="m 424.91,23.22 4.34,-2.604 m -3.48,0.864 2.604,-1.736 m -1.734,3.476 1.736,-0.868"
+         id="path90"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     clip-path="url(#a)"
+     transform="matrix(0.02976,0,0,-0.02902,6.667,33)"
+     id="g98"
+     style="fill:#00b798">
+    <path
+       d="m 448,448 c -61.772,0 -112,50.23 -112,112 0,61.77 50.228,112 112,112 61.77,0 112,-50.23 112,-112 0,-61.77 -50.23,-112 -112,-112 m 0,448 C 262.72,896 112,745.28 112,560 c 0,-70.587 21.958,-138.3 63.424,-195.89 l 8.818,-12.36 241.36,-340.54 C 430.898,4.16 439.212,0 448.002,0 c 8.788,0 17.102,4.157 22.394,11.21 l 238.36,336.49 11.76,16.3 c 41.53,57.697 63.49,125.41 63.49,196 0,185.28 -150.72,336 -336,336"
+       id="path96"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     clip-path="url(#b)"
+     transform="matrix(0.02976,0,0,-0.02902,46.667,33)"
+     id="g102"
+     style="fill:#ffffff">
+    <path
+       d="m 448,448 c -61.772,0 -112,50.23 -112,112 0,61.77 50.228,112 112,112 61.77,0 112,-50.23 112,-112 0,-61.77 -50.23,-112 -112,-112 m 0,448 C 262.72,896 112,745.28 112,560 c 0,-70.587 21.958,-138.3 63.424,-195.89 l 8.818,-12.36 241.36,-340.54 C 430.898,4.16 439.212,0 448.002,0 c 8.788,0 17.102,4.157 22.394,11.21 l 238.36,336.49 11.76,16.3 c 41.53,57.697 63.49,125.41 63.49,196 0,185.28 -150.72,336 -336,336"
+       id="path100"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g106"
+     style="fill:none;stroke:#ffffff;stroke-width:3.81399989;stroke-linecap:round;stroke-linejoin:round">
+    <path
+       d="m 611.93,11.93 16.148,16.148 M 628.07,11.93 611.922,28.078"
+       id="path104"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g110"
+     style="fill:none;stroke:#00b798;stroke-width:3.81399989;stroke-linecap:round;stroke-linejoin:round">
+    <path
+       d="m 571.93,11.93 16.148,16.148 M 588.07,11.93 571.922,28.078"
+       id="path108"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     d="m 487,30.04 1.004,-6 4.996,4.99 z"
+     id="path112"
+     inkscape:connector-curvature="0"
+     style="fill:#00b798;fill-rule:evenodd" />
+  <g
+     transform="translate(-48,-972.36)"
+     id="g128"
+     style="fill:#00b798">
+    <circle
+       cx="541"
+       cy="987.35999"
+       r="5"
+       id="circle114" />
+    <circle
+       cx="555"
+       cy="987.35999"
+       r="5"
+       id="circle116" />
+    <circle
+       cx="555"
+       cy="996.35999"
+       r="5"
+       id="circle118" />
+    <rect
+       rx="0"
+       ry="0"
+       height="11"
+       width="14"
+       y="982.35999"
+       x="541"
+       id="rect120" />
+    <path
+       d="m 550,987.36 h 10 v 9 h -10 z"
+       id="path122"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 544,993.36 h 11 v 8 h -11 z m -8,-6 h 7 v 6 h -7 z"
+       id="path124"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 536,993.36 8,8 v -8 z"
+       id="path126"
+       inkscape:connector-curvature="0"
+       style="fill-rule:evenodd" />
+  </g>
+  <g
+     id="g132"
+     style="fill:#edeff0">
+    <path
+       d="m 493,14 h 15 v 1 h -15 z m 0,4 h 15 v 1 h -15 z m 3,4 h 12 v 1 h -12 z"
+       id="path130"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     d="m 527,30 1.004,-6 4.996,4.99 z"
+     id="path134"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-rule:evenodd" />
+  <g
+     transform="translate(-8,-972.36)"
+     id="g150"
+     style="fill:#ffffff">
+    <circle
+       cy="987.35999"
+       cx="541"
+       r="5"
+       id="circle136" />
+    <circle
+       cy="987.35999"
+       cx="555"
+       r="5"
+       id="circle138" />
+    <circle
+       cy="996.35999"
+       cx="555"
+       r="5"
+       id="circle140" />
+    <rect
+       rx="0"
+       ry="0"
+       height="11"
+       width="14"
+       y="982.35999"
+       x="541"
+       id="rect142" />
+    <path
+       d="m 550,987.36 h 10 v 9 h -10 z"
+       id="path144"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 544,993.36 h 11 v 8 h -11 z m -8,-6 h 7 v 6 h -7 z"
+       id="path146"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 536,993.36 8,8 v -8 z"
+       id="path148"
+       inkscape:connector-curvature="0"
+       style="fill-rule:evenodd" />
+  </g>
+  <g
+     id="g154"
+     style="fill:#002a50">
+    <path
+       d="m 533,14 h 15 v 1 h -15 z m 0,4 h 15 v 1 h -15 z m 3,4 h 12 v 1 h -12 z"
+       id="path152"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     style="fill:#00b798;fill-opacity:0.4;fill-rule:evenodd;stroke:#00b798;stroke-width:2"
+     inkscape:connector-curvature="0"
+     id="path22-9"
+     d="m 648.9281,29.634982 3,-19.8749995 14.75,-3 5,25.8749995 z" />
+  <g
+     transform="matrix(0.48476454,0,0,0.45988757,553.28295,10.930067)"
+     id="g36-0"
+     style="fill:#ffffff;fill-rule:evenodd">
+    <path
+       d="m 208.31,29.938 3,-19.875 14.75,-3 5,25.875 z"
+       id="path30-1"
+       inkscape:connector-curvature="0"
+       style="fill-opacity:0.4;stroke:#ffffff;stroke-width:2" />
+    <g
+       id="g34-7"
+       style="stroke:#002a50;stroke-width:1.5">
+      <path
+         d="m 223.94,5.063 v 4 h 4 v -4 z m -14.75,3.25 v 4 h 4 v -4 z m -2.88,19.625 v 4 h 4 v -4 z m 23.38,3 v 4 h 4 v -4 z"
+         id="path32-8"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     style="fill:#00b798;fill-rule:evenodd;stroke:#e9edf0;stroke-width:0.70999593"
+     d="m 661.85476,13.218108 v 1.846286 h 1.94154 v -1.846286 z m -7.15957,1.500114 v 1.846296 h 1.94154 v -1.846296 z m -1.39788,9.058372 v 1.846277 h 1.94153 v -1.846277 z m 11.34848,1.384715 v 1.846321 h 1.94152 v -1.846321 z"
+     id="path24-5"
+     inkscape:connector-curvature="0" />
+  <g
+     transform="matrix(0.48476454,0,0,0.45988757,591.28249,10.943769)"
+     id="g36-0-1"
+     style="fill:#ffffff;fill-rule:evenodd">
+    <path
+       d="m 208.31,29.938 3,-19.875 14.75,-3 5,25.875 z"
+       id="path30-1-0"
+       inkscape:connector-curvature="0"
+       style="fill-opacity:0.4;stroke:#ffffff;stroke-width:2" />
+    <g
+       id="g34-7-1"
+       style="stroke:#002a50;stroke-width:1.5">
+      <path
+         d="m 223.94,5.063 v 4 h 4 v -4 z m -14.75,3.25 v 4 h 4 v -4 z m -2.88,19.625 v 4 h 4 v -4 z m 23.38,3 v 4 h 4 v -4 z"
+         id="path32-8-3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -63,7 +63,7 @@ var logger = Logger.getLogger("Drawing");
  * @param {ol.layer.Vector} [options.layer = null] - Openlayers layer that will hosts created features. If none, an empty vector layer will be created.
  * @param {Object} [options.popup = {}] - Popup informations
  * @param {Boolean} [options.popup.display = true] - Specify if popup is displayed when create a drawing
- * @param {Function} [options.popup.function] - Function to display popup informations (params : {geomType / feature / saveFunc(message) / closeFunc()})
+ * @param {Function} [options.popup.function] - Function to display popup informations if you want to cutomise it. You may also provide your own function with params : {geomType / feature / saveFunc(message) / closeFunc()}. This function must return the DOM object of the popup content.
  * @param {Object} [options.layerDescription = {}] - Layer informations to be displayed in LayerSwitcher widget (only if a LayerSwitcher is also added to the map)
  * @param {String} [options.layerDescription.title = "Croquis"] - Layer title to be displayed in LayerSwitcher
  * @param {String} [options.layerDescription.description = "Mon croquis"] - Layer description to be displayed in LayerSwitcher
@@ -114,6 +114,45 @@ var logger = Logger.getLogger("Drawing");
  * @param {String} [options.cursorStyle.strokeColor = "#FFF"] - Cursor stroke color.
  * @param {String} [options.cursorStyle.strokeWidth = 1] - Cursor surrounding stroke width.
  * @param {String} [options.cursorStyle.radius = 6] - Cursor radius.
+ * @example
+ * var drawing = new ol.control.Drawing({
+ *   collapsed : false,
+ *   draggable : true,
+ *   layerswitcher : {
+ *      title : "Dessins",
+ *      description : "Mes dessins..."
+ *   },
+ *   markersList : [{
+ *      src : "http://api.ign.fr/api/images/api/markers/marker_01.png",
+ *      anchor : [0.5, 1]
+ *   }],
+ *   defaultStyles : {},
+ *   cursorStyle : {},
+ *   tools : {
+ *      points : true,
+ *      lines : true,
+ *      polygons :true,
+ *      holes : true,
+ *      text : false,
+ *      remove : true,
+ *      display : true,
+ *      tooltip : true,
+ *      export : true,
+ *      measure : true
+ *   },
+ *   popup : {
+ *      display : true,
+ *      function : function (params) {
+ *          var container = document.createElement("div");
+ *          // - params.geomType;
+ *          // - params.feature;
+ *          // Les 2 fonctions ferment la popup avec ou sans sauvegarde des informations
+ *          // dans les properties de la feature (key : description)
+ *          // - params.saveFunc(message);
+ *          // - params.closeFunc();
+ *          return container;
+ *      }
+ * });
  */
 var Drawing = (function (Control) {
     function Drawing (options) {

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -71,7 +71,7 @@ var logger = Logger.getLogger("Drawing");
  * @param {Boolean} [options.tools.points = true] - Display points drawing tool
  * @param {Boolean} [options.tools.lines = true] - Display lines drawing tool
  * @param {Boolean} [options.tools.polygons = true] - Display polygons drawing tool
- * @param {Boolean} [options.tools.holes = true] - Display polygons with holes drawing tool
+ * @param {Boolean} [options.tools.holes = false] - Display polygons with holes drawing tool
  * @param {Boolean} [options.tools.text = true] - Display text drawing tool
  * @param {Boolean} [options.tools.remove = true] - Display feature removing tool
  * @param {Boolean} [options.tools.display = true] - Display style editing tool
@@ -188,7 +188,7 @@ var Drawing = (function (Control) {
         points : true,
         lines : true,
         polygons : true,
-        holes : true,
+        holes : false,
         text : true,
         remove : true,
         display : true,
@@ -209,7 +209,7 @@ var Drawing = (function (Control) {
         points : "Placer des points",
         lines : "Dessiner des lignes",
         polygons : "Dessiner des polygones",
-        holes : "Dessiner des trous",
+        holes : "Créer des trous sur un polygone",
         text : "Ecrire sur la carte",
         editingTools : "Outils d'édition",
         edit : "Editer les tracés",

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -847,7 +847,9 @@ var Drawing = (function (Control) {
                     });
                 }
             };
+
             var popup = null;
+            var popupByDefault = true;
 
             var displayFunction = this.options.popup.function;
             if (displayFunction && typeof displayFunction === "function") {
@@ -864,14 +866,19 @@ var Drawing = (function (Control) {
                     }
                 });
                 if (popup) {
-                    // FIXME ...
+                    // on est sûr que la popup customisée existe,
+                    // donc on n'utilise pas celle par defaut...
+                    popupByDefault = false;
+                    // FIXME comment forcer le focus sur une div ?
                     popup.tabIndex = -1; // hack sur le focus sur une div ?
                     popup.onblur = function () {
                         context.getMap().removeOverlay(context.popupOvl);
                         context.popupOvl = null;
                     };
                 }
-            } else {
+            }
+            // use popup by default
+            if (popupByDefault) {
                 // function by default
                 popup = this._createLabelDiv({
                     applyFunc : setAttValue,
@@ -881,10 +888,12 @@ var Drawing = (function (Control) {
                     geomType : geomType
                 });
             }
+            // un peu de menage...
             if (this.popupOvl) {
                 this.getMap().removeOverlay(this.popupOvl);
                 this.popupOvl = null;
             }
+            // creation de l'overlay
             this.popupOvl = new Overlay({
                 element : popup,
                 // FIXME : autres valeurs.


### PR DESCRIPTION
Évolutions sur l'outil de dessin suite à 2 remontées du forum : 

* https://www.developpez.net/forums/d2076868/applications/sig-systeme-d-information-geographique/ign-api-geoportail/utiliser-propre-formulaire-fin-dessin-d-polygone/

* https://www.developpez.net/forums/d2076864/applications/sig-systeme-d-information-geographique/ign-api-geoportail/dessiner-polygone-trou/

Possibilité de choisir d'**afficher les popup** d'informations, ainsi que de **surcharger le formulaire** :  
```
var drawing = new ol.control.Drawing({
        popup : {
            display : true,
            apply : function (params) {
                  var element = document.createElement('div');
                  element.className = "popup";
                  console.log(params.geomType);
                  var message = "";
                  var props = params.feature.getProperties();
                  for (const property in props) {
                              message += property;
                              message += " : ";
                              message += props[property];
                              message += "<br>";
                  }
                  element.innerHTML = message;
                  return element;
              }
          }
});
```

Mise en place d'un outil qui permet de trouer des polygones : 
![image](https://user-images.githubusercontent.com/10401006/82383948-21d57880-9a2f-11ea-835e-89794f465717.png)

Une option permet de désactiver cet outil : 
```
var drawing = new ol.control.Drawing({
  tools : {
    holes : false
  }
});
```