### PR TITLE
Retrait de la limitation du nombre d'affichage des resultats de l'autocompletion

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -44,6 +44,8 @@
 
 * [Changed]
 
+    - Retrait de la limitation d'affichage des reponses de l'autocompletion sur le Widget *SearchEngine* (cf. <https://www.developpez.net/forums/d2125691/applications/sig-systeme-d-information-geographique/ign-api-geoportail/geoportal-extension-searchengine-autocomplete-maximum-5-reponses/#post11811536>)
+
 * [Deprecated]
 
 * [Removed]

--- a/src/OpenLayers/CSS/Controls/SearchEngine/GPsearchEngineOpenLayers.css
+++ b/src/OpenLayers/CSS/Controls/SearchEngine/GPsearchEngineOpenLayers.css
@@ -47,6 +47,7 @@
 [id^="GPgeocodeResultsList"] {
   margin-left: 33px;
   box-shadow: 0 0 6px #000;
+  overflow-y: auto;
 }
 
 [id^="GPgeocodeResultsList"] {


### PR DESCRIPTION
Ajout d'un ascenseur (en mode auto)  sur la fenêtre de résultats de l'autocompletion du widget **SearcEngine** : 
![image](https://user-images.githubusercontent.com/10401006/152779089-46336fb1-bcd9-443a-b701-b5d6be460c15.png)

cf. https://www.developpez.net/forums/d2125691/applications/sig-systeme-d-information-geographique/ign-api-geoportail/geoportal-extension-searchengine-autocomplete-maximum-5-reponses/#post11811536