### PR TITLE
Fix sur le style des elements en cours d'édition

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -20,6 +20,8 @@
 
 * [Fixed]
 
+    - Correctif du style des elements en cours d'édition lors de l'export / enregistrement des croquis sur l'outil de dessin
+
 * [Security]
 
 ---

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -52,6 +52,7 @@ import KMLExtended from "../Formats/KML";
 import GeoJSONExtended from "../Formats/GeoJSON";
 import GPXExtended from "../Formats/GPX";
 import LayerSwitcher from "./LayerSwitcher";
+import { textHeights } from "ol/render/canvas";
 
 var logger = Logger.getLogger("Drawing");
 
@@ -372,6 +373,9 @@ var Drawing = (function (Control) {
             logger.log("Impossible to export : no features found.");
             return result;
         }
+
+        // on invalide les features...
+        this.featuresCollectionSelected.clear();
 
         var ClassName = null;
         switch (this.getExportFormat()) {
@@ -717,6 +721,7 @@ var Drawing = (function (Control) {
 
         this.interactionCurrent = null;
         this.interactionSelectEdit = null;
+        this.featuresCollectionSelected = null;
 
         this.stylingOvl = null;
         this.popupOvl = null;
@@ -1860,11 +1865,15 @@ var Drawing = (function (Control) {
                 break;
             case this._addUID("drawing-tool-edit"):
                 if (context.dtOptions["edit"].active) {
+                    this.featuresCollectionSelected = new Collection();
                     context.interactionSelectEdit = new SelectInteraction({
                         condition : eventSingleClick,
-                        layers : [this.layer]
+                        layers : [this.layer],
+                        features : this.featuresCollectionSelected
                     });
-
+                    context.interactionSelectEdit.on("select", (e) => {
+                        // ...
+                    });
                     context.interactionSelectEdit.setProperties({
                         name : "Drawing",
                         source : context

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -52,7 +52,6 @@ import KMLExtended from "../Formats/KML";
 import GeoJSONExtended from "../Formats/GeoJSON";
 import GPXExtended from "../Formats/GPX";
 import LayerSwitcher from "./LayerSwitcher";
-import { textHeights } from "ol/render/canvas";
 
 var logger = Logger.getLogger("Drawing");
 


### PR DESCRIPTION
Correctif du style des éléments en cours d'édition lors de l'export / enregistrement des croquis sur l'outil de dessin.

Lors de la sélection d'un élément à modifier, le style en surbrillance est ajouté au _feature_ sélectionné.
Si on procède à l'export sans avoir au préalable validé la modification du _feature_, le style de surbrillance est enregistré dans l'export.

La correction consiste à invalider les _features_ en cours d'édition avant de lancer l'export ou l’enregistrement.

Comment tester ?
- créer un croquis
- sélectionner un élément (feature) pour modification
- ne pas invalider la modification (toujours en surbrillance)
- exporter le croquis
- importer ce même croquis
> le style doit être correctement appliqué !