### PR TITLE
Fix sur la saisie sous les tooltips avec les outils de mesures

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -20,6 +20,8 @@
 
 * [Fixed]
 
+    - Permettre la saisie sous la tooltip sur les outils de mesures
+
 * [Security]
 
 ---

--- a/src/OpenLayers/Controls/Measures/Measures.js
+++ b/src/OpenLayers/Controls/Measures/Measures.js
@@ -339,6 +339,7 @@ var Measures = {
 
         this.measureTooltip = new Overlay({
             element : this.measureTooltipElement,
+            stopEvent : false,
             offset : [0, -15],
             positioning : "bottom-center"
         });
@@ -362,6 +363,7 @@ var Measures = {
 
         this.helpTooltip = new Overlay({
             element : this.helpTooltipElement,
+            stopEvent : false,
             offset : [15, 0],
             positioning : "center-left"
         });


### PR DESCRIPTION
Les outils de mesures ne permettaient pas la saisie de point sous la **tooltip** de mesure.
(remontée utilisateur)