### PR TITLE
Fix sur le nettoyage des tooltips des outils de mesures

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -23,6 +23,7 @@
     - Permettre la saisie sous la tooltip sur les outils de mesures
     - Correctif du style des elements en cours d'édition lors de l'export / enregistrement des croquis sur l'outil de dessin
     - Desactivation des interactions à la fermeture de l'outil de dessin [#323](https://github.com/IGNF/geoportal-extensions/issues/323)
+    - Nettoyage des tooltips des outils de mesures
 
 * [Security]
 

--- a/src/OpenLayers/Controls/Measures/Measures.js
+++ b/src/OpenLayers/Controls/Measures/Measures.js
@@ -278,7 +278,7 @@ var Measures = {
 
         var mapContainer = map.getTargetElement();
         // au cas où il y'aurait plusieurs container de carte !
-        var overlays = mapContainer.getElementsByClassName("ol-overlaycontainer-stopevent");
+        var overlays = mapContainer.getElementsByClassName("ol-overlaycontainer");
         for (var k = 0; k < overlays.length; k++) {
             var nodes = overlays[k];
             var len = nodes.children.length;


### PR DESCRIPTION
A la suppression de la couche ou à la désactivation des mesures, on nettoie correctement les **tooltips** sur la carte.