### PR TITLE
feat(leaflet-route): more options passed to route

### DIFF
--- a/src/Leaflet/Controls/Route.js
+++ b/src/Leaflet/Controls/Route.js
@@ -751,6 +751,10 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
         this._currentComputation = options.computation;
         this._currentExclusions = options.exclusions;
 
+        if (typeof this.options.routeOptions.geometryInInstructions === "undefined") {
+            this.options.routeOptions.geometryInInstructions = true;
+        }
+
         // mise en place de la patience
         this._displayWaitingContainer();
 
@@ -763,13 +767,16 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
             graph : this._currentTransport,
             routePreference : this._currentComputation,
             exclusions : this._currentExclusions,
-            geometryInInstructions : true, // surcharge obligatoire !
+            geometryInInstructions : this.options.routeOptions.geometryInInstructions,
             distanceUnit : "m", // surcharge obligatoire !
             // callback onSuccess
             onSuccess : function (results) {
                 logger.log(results);
                 if (results) {
                     context._fillRouteResultsDetails(results);
+                    if (context.options.routeOptions.onSuccess) {
+                        context.options.routeOptions.onSuccess(results);
+                    }
                 }
             },
             // callback onFailure
@@ -1050,12 +1057,14 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
             this._fillRouteResultsDetailsGeometry(geometry);
         }
 
-        // existe t il une geometrie pour chaque troncon de route ?
-        var bGeometryInstructions = (instructions && Array.isArray(instructions) && instructions[0].geometry.length !== 0);
+        if (this.options.routeOptions.geometryInInstructions) {
+            // existe t il une geometrie pour chaque troncon de route ?
+            var bGeometryInstructions = (instructions && Array.isArray(instructions) && instructions[0].geometry.length !== 0);
 
-        // Geometries des tronçon
-        if (instructions && bGeometryInstructions) {
-            this._fillRouteResultsDetailsFeatureGeometry(instructions);
+            // Geometries des tronçon
+            if (instructions && bGeometryInstructions) {
+                this._fillRouteResultsDetailsFeatureGeometry(instructions);
+            }
         }
 
         // Emprise
@@ -1114,9 +1123,9 @@ var Route = L.Control.extend(/** @lends L.geoportalControl.Route.prototype */ {
         var map = this._map;
 
         var _style = {
-            color : "#ff7800",
+            color : "#ED7F10",
             weight : 5,
-            opacity : 0.65
+            opacity : 0.75
         };
 
         this._geojsonRoute = L.geoJson(geometry, {


### PR DESCRIPTION
Prise en compte des options routeOptions.onSuccess et routeOptions.geometryInInstructions passées à la création du widget

## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [x] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [x] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->
Les options `routeOptions.onSuccess` et `routeOptions.geometryInInstructions` dans le code d'exemple suivant 
```js
  // Geoportail widget route
  const route = L.geoportalControl.Route({
    apiKey: "calcul",
    disableReverse: true,
    graphs: ["Pieton"],
    routeOptions: {
      onSuccess: computeRouteElevation,
      geometryInInstructions: false,
    },
  });
  map.addControl(route);
```
ne sont pas prises en compte.

Numéro du ticket : N/A


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Ces deux options sont désormais prises en compte

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
