### PR TITLE
Ajout des modules dans la JSdoc

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,7 +22,8 @@
 
 * [Fixed]
 
-    - faute d'ortographe description couche Isocurve
+    - Faute d'ortographe description couche Isocurve
+    - Ajout des modules dans la JSDoc
 
 * [Security]
 

--- a/src/OpenLayers/Controls/Drawing.js
+++ b/src/OpenLayers/Controls/Drawing.js
@@ -163,6 +163,14 @@ var logger = Logger.getLogger("Drawing");
  * });
  */
 var Drawing = (function (Control) {
+    /**
+     * See {@link ol.control.Drawing}
+     * @module Drawing
+     * @alias module:~Controls/Drawing
+     * @param {*} options - options
+     * @example
+     * import Drawing from "src/OpenLayers/Controls/Drawing"
+     */
     function Drawing (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/ElevationPath.js
+++ b/src/OpenLayers/Controls/ElevationPath.js
@@ -94,6 +94,14 @@ var logger = Logger.getLogger("elevationpath");
  *
  */
 var ElevationPath = (function (Control) {
+    /**
+     * See {@link ol.control.ElevationPath}
+     * @module ElevationPath
+     * @alias module:~Controls/ElevationPath
+     * @param {*} options - options
+     * @example
+     * import ElevationPath from "src/OpenLayers/Controls/ElevationPath"
+     */
     function ElevationPath (options) {
         logger.trace("ElevationPath()");
 

--- a/src/OpenLayers/Controls/GeoportalAttribution.js
+++ b/src/OpenLayers/Controls/GeoportalAttribution.js
@@ -28,6 +28,14 @@ var logger = Logger.getLogger("geoportalattribution");
  * attribution.on("attributions:update", function (e) {});
  */
 var GeoportalAttribution = (function (Attribution) {
+    /**
+     * See {@link ol.control.GeoportalAttribution}
+     * @module GeoportalAttribution
+     * @alias module:~Controls/GeoportalAttribution
+     * @param {*} options - options
+     * @example
+     * import GeoportalAttribution from "src/OpenLayers/Controls/GeoportalAttribution"
+     */
     function GeoportalAttribution (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/GetFeatureInfo.js
+++ b/src/OpenLayers/Controls/GetFeatureInfo.js
@@ -42,6 +42,14 @@ var logger = Logger.getLogger("getfeatureinfo");
  * @param {Number} [options.options.autoPanMargin] - Margin (in pixels) between the pop-up and the border of the map when autopanning. Default is 20.
  */
 var GetFeatureInfo = (function (Control) {
+    /**
+     * See {@link ol.control.GetFeatureInfo}
+     * @module GetFeatureInfo
+     * @alias module:~Controls/GetFeatureInfo
+     * @param {*} options - options
+     * @example
+     * import GetFeatureInfo from "src/OpenLayers/Controls/GetFeatureInfo"
+     */
     function GetFeatureInfo (options) {
         options = options || {};
         var _options = options.options || {};

--- a/src/OpenLayers/Controls/Isocurve.js
+++ b/src/OpenLayers/Controls/Isocurve.js
@@ -78,6 +78,14 @@ var logger = Logger.getLogger("isocurve");
  *  });
  */
 var Isocurve = (function (Control) {
+    /**
+     * See {@link ol.control.Isocurve}
+     * @module Isocurve
+     * @alias module:~Controls/Isocurve
+     * @param {*} options - options
+     * @example
+     * import Isocurve from "src/OpenLayers/Controls/Isocurve"
+     */
     function Isocurve (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/LayerImport.js
+++ b/src/OpenLayers/Controls/LayerImport.js
@@ -136,6 +136,14 @@ var logger = Logger.getLogger("layerimport");
  *  });
  */
 var LayerImport = (function (Control) {
+    /**
+     * See {@link ol.control.LayerImport}
+     * @module LayerImport
+     * @alias module:~Controls/LayerImport
+     * @param {*} options - options
+     * @example
+     * import LayerImport from "src/OpenLayers/Controls/LayerImport"
+     */
     function LayerImport (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/LayerSwitcher.js
+++ b/src/OpenLayers/Controls/LayerSwitcher.js
@@ -51,6 +51,14 @@ var logger = Logger.getLogger("layerswitcher");
  * ));
  */
 var LayerSwitcher = (function (Control) {
+    /**
+     * See {@link ol.control.LayerSwitcher}
+     * @module LayerSwitcher
+     * @alias module:~Controls/LayerSwitcher
+     * @param {*} options - options
+     * @example
+     * import LayerSwitcher from "src/OpenLayers/Controls/LayerSwitcher"
+     */
     function LayerSwitcher (options) {
         options = options || {};
         var _options = options.options || {};

--- a/src/OpenLayers/Controls/LocationSelector.js
+++ b/src/OpenLayers/Controls/LocationSelector.js
@@ -56,6 +56,14 @@ var logger = Logger.getLogger("locationselector");
  *  });
  */
 var LocationSelector = (function (Control) {
+    /**
+     * See {@link ol.control.LocationSelector}
+     * @module LocationSelector
+     * @alias module:~Controls/LocationSelector
+     * @param {*} options - options
+     * @example
+     * import LocationSelector from "src/OpenLayers/Controls/LocationSelector"
+     */
     function LocationSelector (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/MousePosition.js
+++ b/src/OpenLayers/Controls/MousePosition.js
@@ -118,6 +118,14 @@ var logger = Logger.getLogger("GeoportalMousePosition");
  * });
  */
 var MousePosition = (function (Control) {
+    /**
+     * See {@link ol.control.GeoportalMousePosition}
+     * @module MousePosition
+     * @alias module:~Controls/MousePosition
+     * @param {*} options - options
+     * @example
+     * import GeoportalMousePosition from "src/OpenLayers/Controls/MousePosition"
+     */
     function MousePosition (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/ReverseGeocode.js
+++ b/src/OpenLayers/Controls/ReverseGeocode.js
@@ -72,6 +72,14 @@ var logger = Logger.getLogger("reversegeocoding");
  *  });
  */
 var ReverseGeocode = (function (Control) {
+    /**
+     * See {@link ol.control.ReverseGeocode}
+     * @module ReverseGeocode
+     * @alias module:~Controls/ReverseGeocode
+     * @param {*} options - options
+     * @example
+     * import ReverseGeocode from "src/OpenLayers/Controls/ReverseGeocode"
+     */
     function ReverseGeocode (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/Route.js
+++ b/src/OpenLayers/Controls/Route.js
@@ -88,6 +88,14 @@ var logger = Logger.getLogger("route");
  *  });
  */
 var Route = (function (Control) {
+    /**
+     * See {@link ol.control.Route}
+     * @module Route
+     * @alias module:~Controls/Route
+     * @param {*} options - options
+     * @example
+     * import Route from "src/OpenLayers/Controls/Route"
+     */
     function Route (options) {
         options = options || {};
 

--- a/src/OpenLayers/Controls/SearchEngine.js
+++ b/src/OpenLayers/Controls/SearchEngine.js
@@ -72,6 +72,14 @@ var logger = Logger.getLogger("searchengine");
  *  });
  */
 var SearchEngine = (function (Control) {
+    /**
+     * See {@link ol.control.SearchEngine}
+     * @module SearchEngine
+     * @alias module:~Controls/SearchEngine
+     * @param {*} options - options
+     * @example
+     * import SearchEngine from "src/OpenLayers/Controls/SearchEngine"
+     */
     function SearchEngine (options) {
         options = options || {};
 

--- a/src/OpenLayers/Formats/GPX.js
+++ b/src/OpenLayers/Formats/GPX.js
@@ -28,6 +28,14 @@ import Parser from "../../Common/Utils/Parser";
  * @param {function} options.readExtensions - Reading extensions (native)
  */
 var GPX = (function (olGPX) {
+    /**
+     * See {@link ol.format.GPXExtended}
+     * @module GPXExtended
+     * @alias module:~Formats/GPXExtended
+     * @param {*} options - options
+     * @example
+     * import GPXExtended from "src/OpenLayers/Formats/GPX"
+     */
     function GPX (options) {
         if (!(this instanceof GPX)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/OpenLayers/Formats/GeoJSON.js
+++ b/src/OpenLayers/Formats/GeoJSON.js
@@ -27,6 +27,14 @@ import Color from "../../Common/Utils/ColorUtils";
  * @param {Object} options.defaultStyle - Styles by default
  */
 var GeoJSON = (function (olGeoJSON) {
+    /**
+     * See {@link ol.format.GeoJSONExtended}
+     * @module SearchEngine
+     * @alias module:~Formats/GeoJSONExtended
+     * @param {*} options - options
+     * @example
+     * import GeoJSONExtended from "src/OpenLayers/Formats/GeoJSON"
+     */
     function GeoJSON (options) {
         if (!(this instanceof GeoJSON)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/OpenLayers/Formats/KML.js
+++ b/src/OpenLayers/Formats/KML.js
@@ -42,6 +42,14 @@ var logger = Logger.getLogger("extended KML format");
  * @param {Object} options - Options
  */
 var KML = (function (olKML) {
+    /**
+     * See {@link ol.format.KMLExtended}
+     * @module KMLExtended
+     * @alias module:~Formats/KMLExtended
+     * @param {*} options - options
+     * @example
+     * import KMLExtended from "src/OpenLayers/Formats/KML"
+     */
     function KML (options) {
         if (!(this instanceof KML)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/OpenLayers/Layers/LayerWMS.js
+++ b/src/OpenLayers/Layers/LayerWMS.js
@@ -18,7 +18,7 @@ import SourceWMS from "./SourceWMS";
  * @extends {ol.layer.Tile}
  * @alias ol.layer.GeoportalWMS
  * @type {ol.layer.GeoportalWMS}
- * @param {Object} options            - options for function call.
+ * @param {Object} GeoportalWMSoptions            - options for function call.
  * @param {String} options.layer      - Layer name (e.g. "ORTHOIMAGERY.ORTHOPHOTOS")
  * @param {Boolean} [options.ssl]     - if set true, enforce protocol https (only for nodejs)
  * @param {String} [options.apiKey]   - Access key to Geoportal platform
@@ -30,6 +30,14 @@ import SourceWMS from "./SourceWMS";
  * });
  */
 var LayerWMS = (function (TileLayer) {
+    /**
+     * See {@link ol.layer.GeoportalWMS}
+     * @module LayerWMS
+     * @alias module:~Layers/GeoportalWMS
+     * @param {*} options - options
+     * @example
+     * import LayerWMS from "src/OpenLayers/Layers/LayerWMS"
+     */
     function LayerWMS (options) {
         if (!(this instanceof LayerWMS)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");

--- a/src/OpenLayers/Layers/LayerWMTS.js
+++ b/src/OpenLayers/Layers/LayerWMTS.js
@@ -27,6 +27,14 @@ import SourceWMTS from "./SourceWMTS";
  * });
  */
 var LayerWMTS = (function (TileLayer) {
+    /**
+     * See {@link ol.layer.GeoportalWMTS}
+     * @module LayerWMTS
+     * @alias module:~Layers/GeoportalWMTS
+     * @param {*} options - options
+     * @example
+     * import LayerWMTS from "src/OpenLayers/Layers/LayerWMTS"
+     */
     function LayerWMTS (options) {
         if (!(this instanceof LayerWMTS)) {
             throw new TypeError("ERROR CLASS_CONSTRUCTOR");


### PR DESCRIPTION
Liste exhaustive des modules : 
![image](https://user-images.githubusercontent.com/10401006/217890647-41b6597b-3daa-4806-af8e-a7d9d1ef3168.png)

Ceci permet de connaitre le chemin des modules pour un appel ES6 module :
![image](https://user-images.githubusercontent.com/10401006/217890407-f4ab1260-466b-4e58-a44a-8956ac4e13ea.png)

> Pour info, cette demande est liée à l'issue #345 : _comment connaitre la liste des modules importables_