### PR TITLE
Ajout event sur le controle ReverseGeocode (ol)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -12,6 +12,7 @@
 * [Added]
 
     - Ajout d'evenements sur le contrôle SearchEngine lors de la selection d'un résultat
+    - Ajout d'evenements sur le contrôle ReverseGeocode lors de la selection d'un résultat
     - Ajout de méthodes publiques sur les contrôles Iso et Route : 
       - getGeoJSON() : fournit le tracé au format GeoJSON
       - getData() : fournit la configuration du calcul

--- a/samples-src/pages/openlayers/ReverseGeocode/pages-ol-reversegeocode-bundle-cb.html
+++ b/samples-src/pages/openlayers/ReverseGeocode/pages-ol-reversegeocode-bundle-cb.html
@@ -57,9 +57,11 @@
 
                 // listener sur le calcul
                 reverse.on("reversegeocode:compute", function (e) {
-                  console.warn(e.target.getData());
+                  console.error(e.target.getData());
                 });
-
+                reverse.on("reversegeocode:onclickresult", function (e) {
+                  console.error(e.location);
+                });
                 layerSwitcher = new ol.control.LayerSwitcher({});
                 map.addControl(layerSwitcher);
              };


### PR DESCRIPTION
Ajout de l’événement _'reversegeocode:onclickresult'_ sur le contrôle **ReverseGeocode** pour OpenLayers
cf. #355 
