### PR TITLE
Correction du paramétrage des ressources à utiliser avec le SearchEngine (Ol + Leaflet)

### DIFF
--- a/src/Common/Utils.js
+++ b/src/Common/Utils.js
@@ -70,7 +70,7 @@ var Utils = {
      * @param {Boolean} replace - replace destination value by source if exists or not (true by default)
      */
     mergeParams : function (dest, source, replace) {
-        if (typeof dest === 'undefined' || typeof source === 'undefined' ) {
+        if (typeof dest === "undefined" || typeof source === "undefined") {
             return;
         }
         if (typeof replace === "undefined") {

--- a/src/Common/Utils.js
+++ b/src/Common/Utils.js
@@ -70,7 +70,7 @@ var Utils = {
      * @param {Boolean} replace - replace destination value by source if exists or not (true by default)
      */
     mergeParams : function (dest, source, replace) {
-        if (!dest || !source) {
+        if (typeof dest === 'undefined' || typeof source === 'undefined' ) {
             return;
         }
         if (typeof replace === "undefined") {

--- a/src/OpenLayers/Controls/SearchEngine.js
+++ b/src/OpenLayers/Controls/SearchEngine.js
@@ -206,7 +206,7 @@ var SearchEngine = (function (Control) {
             collapsed : true,
             zoomTo : "",
             resources : {
-                geocode : "",
+                geocode : [],
                 autocomplete : []
             },
             displayAdvancedSearch : true,
@@ -227,7 +227,7 @@ var SearchEngine = (function (Control) {
         // merge with user options
         Utils.mergeParams(this.options, options);
         if (this.options.resources.geocode === "") {
-            this.options.resources.geocode = "address,poi";
+            this.options.resources.geocode = ["PositionOfInterest", "StreetAddress"];
         }
         if (this.options.resources.autocomplete.length === 0) {
             this.options.resources.autocomplete = ["PositionOfInterest", "StreetAddress"];


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [x] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [x] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :

Imposible de paramétrer les ressources à utiliser sur le SearchEngine (limité les entrées de la listes déroulantes selon son paramétrage)


## Quel est le nouveau comportement :

Les options par défaut sont prises en compte, et le paramétre resources.geocode est bien pris en compte sur les extensions OpenLayer et Leaflet.

**Exemple d'utilisation avec extension Géoplateforme pour Leaflet :** 
```
var search = L.geoportalControl.SearchEngine({
              collapsed : false,
              displayInfo : true,
              placeholder : "Recherche de points d'interêt...",
              displayMarker : true,
              markerStyle : "green",
              zoomTo : "auto",
              resources : {
                geocode: ["CadastralParcel"]
              },
              position : "bottomright",
              displayAdvancedSearch : true,
              advancedSearch : {}
            });
```
--> Seules les parcelles cadastrales peuvent être recherchée en recherche avancée.

**Exemple d'utilisation avec extension Géoplateforme pour OpenLayers :** 
```
                    var search = new ol.control.SearchEngine({
                        collapsed : false,
                        displayAdvancedSearch : true,
                        advancedSearch : {
                          PositionOfInterest : [
                            {name : "nature", title : "Nature"},
                            {name : "municipality", title : "Ville"},
                            {name : "department", title : "Departement", value : "77"}
                          ],
                          // on ne veut pas configurer cette entrée qui est donc présente mais inactive !
                          StreetAddress : null || [], 

                        },
                        resources : {
                          geocode : ["CadastralParcel", "StreetAddress", "PositionOfInterest"],
                          autocomplete : ["PositionOfInterest"]
                          // autocomplete : ["StreetAddress", "test"]
                        },
                        geocodeOptions : {
                          serviceOptions : {
                            filterOptions : {
                              type : ["PositionOfInterest"],
                              // department : "31"
                            },
                            maximumResponses : 5,
                            returnFreeForm : false,
                            // rawResponse : true
                          }    
                        },
                        autocompleteOptions : {
                          filterOptions : {
                            type : ["StreetAddress", "PositionOfInterest"],
                          }
                        },
                        // valeur possible : "" ou null, "auto", 18, function (i) { return 1; }
                        zoomTo : "auto",
                        placeholder : "Recherche...",
                        markerDisplay : true,
                        markerStyle : "turquoiseBlue"
                    });
```
--> On recherche sur les trois index possible, mais en recherche avancée, le paramétrage interdit la recherche sur StreetAdress

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

Attention à bien vérifié que rien ne casse dans les briques en aval.
Si validées, modifications à reporter sur le projet extensions-openlayers.
